### PR TITLE
OneShot mode for envelopes

### DIFF
--- a/src/dsp/node_support.h
+++ b/src/dsp/node_support.h
@@ -37,11 +37,16 @@ enum TriggerMode
     NEW_VOICE,
     KEY_PRESS,
     PATCH_DEFAULT,
-    ON_RELEASE
+    ON_RELEASE,
+    ONE_SHOT
 };
 
-static const char *TriggerModeName[5]{"On Start or In Release (Legato)", "On Start Voice Only",
-                                      "On Any Key Press", "Patch Default", "On Release"};
+static const char *TriggerModeName[6]{"On Start or In Release (Legato)",
+                                      "On Start Voice Only",
+                                      "On Any Key Press",
+                                      "Patch Default",
+                                      "On Release",
+                                      "One Shot (w/ Default Retrigger)"};
 
 template <typename T> struct EnvelopeSupport
 {
@@ -169,6 +174,12 @@ template <typename T> struct EnvelopeSupport
             env.processBlockWithDelay(delay, std::clamp(attackv + attackMod, minAttack, 1.f), hold,
                                       decay, sustain, release, ash, dsh, rsh, !voiceValues.gated,
                                       needsCurve);
+        }
+        else if (triggerMode == ONE_SHOT)
+        {
+            env.processBlockWithDelay(delay, std::clamp(attackv + attackMod, minAttack, 1.f), hold,
+                                      decay, sustain, release, ash, dsh, rsh,
+                                      env.stage < env_t::s_sustain, needsCurve);
         }
         else
         {

--- a/src/synth/voice.cpp
+++ b/src/synth/voice.cpp
@@ -132,7 +132,8 @@ void Voice::retriggerAllEnvelopesForKeyPress()
             return false;
 
         auto res = (tm == TriggerMode::KEY_PRESS ||
-                    (tm == TriggerMode::PATCH_DEFAULT && dtm == TriggerMode::KEY_PRESS));
+                    ((tm == TriggerMode::PATCH_DEFAULT || tm == ONE_SHOT) &&
+                     dtm == TriggerMode::KEY_PRESS));
         return res;
     };
     for (auto &s : src)

--- a/src/ui/dahdsr-components.h
+++ b/src/ui/dahdsr-components.h
@@ -145,6 +145,9 @@ template <typename Comp, typename PatchPart> struct DAHDSRComponents
         case (int)TriggerMode::ON_RELEASE:
             triggerButton->setLabel("R");
             break;
+        case (int)TriggerMode::ONE_SHOT:
+            triggerButton->setLabel("1");
+            break;
         case (int)TriggerMode::PATCH_DEFAULT:
             triggerButton->setLabel("D");
             break;
@@ -174,9 +177,9 @@ template <typename Comp, typename PatchPart> struct DAHDSRComponents
         auto p = juce::PopupMenu();
         p.addSectionHeader("Trigger Mode");
         p.addSeparator();
-        for (auto v :
-             {(int)TriggerMode::KEY_PRESS, (int)TriggerMode::NEW_GATE, (int)TriggerMode::NEW_VOICE,
-              (int)TriggerMode::ON_RELEASE, (int)TriggerMode::PATCH_DEFAULT})
+        for (auto v : {(int)TriggerMode::KEY_PRESS, (int)TriggerMode::NEW_GATE,
+                       (int)TriggerMode::NEW_VOICE, (int)TriggerMode::ON_RELEASE,
+                       (int)TriggerMode::ONE_SHOT, (int)TriggerMode::PATCH_DEFAULT})
         {
             bool enabled = true;
             if (v == (int)TriggerMode::NEW_VOICE && !voiceTrigerAllowed)


### PR DESCRIPTION
Enveloeps can be in oneshot mode, which means they are gated when stage < sustain and self run

They retrigger following the patch default retrigger rule.

Closes #62