### PR TITLE
Make sst-plugininfra static explicitly. Warn if you change BSLIBS

### DIFF
--- a/cmake/compile-options.cmake
+++ b/cmake/compile-options.cmake
@@ -7,6 +7,10 @@ if (APPLE)
 endif()
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Never want shared if not specified")
+if (${BUILD_SHARED_LIBS})
+    message(WARNING "You have set BUILD_SHARED_LIBS to ON. This is an untested and unlikedly to work config")
+endif()
+
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
I explicitly set BUILD_SHARED_LIBS to OFF but if you override that then now I show a warning also. Considered making this a fatal error but there's a chance that this project might work in that config.

Addresses #111