### PR TITLE
Sin Table Fixes

### DIFF
--- a/src/dsp/matrix_node.h
+++ b/src/dsp/matrix_node.h
@@ -349,7 +349,7 @@ struct MixerNode : EnvelopeSupport<Patch::MixerNode>,
 
             auto wf = (SinTable::WaveForm)(from.waveForm);
             if (wf == SinTable::TX3 || wf == SinTable::TX4 || wf == SinTable::TX7 ||
-                wf == SinTable::TX8)
+                wf == SinTable::TX8 || wf == SinTable::SPIKY_TX4 || wf == SinTable::SPIKY_TX8)
             {
                 doBlock = true;
             }

--- a/src/dsp/sintable.cpp
+++ b/src/dsp/sintable.cpp
@@ -144,6 +144,23 @@ void SinTable::initializeStatics()
                   return std::make_pair(-v, -dv);
               });
 
+    fillTable(WaveForm::TRIANGLE,
+              [](double x, int Q)
+              {
+                  if (Q == 0)
+                  {
+                      return std::make_pair(4 * x, 4.0);
+                  }
+                  else if (Q == 3)
+                  {
+                      return std::make_pair(4 * x - 4, 4.0);
+                  }
+                  else
+                  {
+                      return std::make_pair(2.0 - 4.0 * x, -4.0);
+                  }
+                  return std::make_pair(0.0, 0.0);
+              });
     fillTable(WaveForm::SIN_OF_CUBED,
               [](double x, int Q)
               {
@@ -157,7 +174,25 @@ void SinTable::initializeStatics()
                   return std::make_pair(v, dv);
               });
 
-    fillTable(SinTable::WaveForm::TX2,
+    fillTable(SinTable::TX2,
+              [](double x, int Q) -> std::pair<double, double>
+              {
+                  auto v = 0.0;
+                  auto dv = 0.0;
+                  if (Q == 0 || Q == 1)
+                  {
+                      v = 0.5 * (sin(4.0 * M_PI * (x - 0.125)) + 1);
+                      dv = 2.0 * M_PI * cos(4.0 * M_PI * (x - 0.125));
+                  }
+                  else
+                  {
+                      v = -0.5 * (sin(4.0 * M_PI * (x - 0.125)) + 1);
+                      dv = -2.0 * M_PI * cos(4.0 * M_PI * (x - 0.125));
+                  }
+                  return {v, dv};
+              });
+
+    fillTable(SinTable::WaveForm::SPIKY_TX2,
               [](double x, int Q)
               {
                   double v, dv;
@@ -211,7 +246,21 @@ void SinTable::initializeStatics()
                   return std::make_pair(v, dv);
               });
 
-    fillTable(SinTable::WaveForm::TX4,
+    fillTable(SinTable::TX4,
+              [](double x, int Q) -> std::pair<double, double>
+              {
+                  auto v = 0.0;
+                  auto dv = 0.0;
+                  if (Q == 0 || Q == 1)
+                  {
+                      v = 0.5 * (sin(4.0 * M_PI * (x - 0.125)) + 1);
+                      dv = 2.0 * M_PI * cos(4.0 * M_PI * (x - 0.125));
+                  }
+
+                  return {v, dv};
+              });
+
+    fillTable(SinTable::WaveForm::SPIKY_TX4,
               [](double x, int Q)
               {
                   double v, dv;
@@ -263,6 +312,23 @@ void SinTable::initializeStatics()
               });
 
     fillTable(SinTable::WaveForm::TX6,
+              [](double x, int Q) -> std::pair<double, double>
+              {
+                  auto v = 0.0;
+                  auto dv = 0.0;
+                  if (Q == 0)
+                  {
+                      v = 0.5 * (sin(8.0 * M_PI * (x - 0.0625)) + 1);
+                      dv = 4.0 * M_PI * cos(8.0 * M_PI * (x - 0.0625));
+                  }
+                  else if (Q == 1)
+                  {
+                      v = -0.5 * (sin(8.0 * M_PI * (x - 0.0625)) + 1);
+                      dv = -4.0 * M_PI * cos(8.0 * M_PI * (x - 0.0625));
+                  }
+                  return {v, dv};
+              });
+    fillTable(SinTable::WaveForm::SPIKY_TX6,
               [](double x, int Q)
               {
                   double v{0}, dv{0};
@@ -328,6 +394,19 @@ void SinTable::initializeStatics()
               });
 
     fillTable(SinTable::WaveForm::TX8,
+              [](double x, int Q) -> std::pair<double, double>
+              {
+                  auto v = 0.0;
+                  auto dv = 0.0;
+                  if (Q == 0 || Q == 1)
+                  {
+                      v = 0.5 * (sin(8.0 * M_PI * (x - 0.0625)) + 1);
+                      dv = 4.0 * M_PI * cos(8.0 * M_PI * (x - 0.0625));
+                  }
+
+                  return {v, dv};
+              });
+    fillTable(SinTable::WaveForm::SPIKY_TX8,
               [](double x, int Q)
               {
                   double v{0}, dv{0};

--- a/src/dsp/sintable.h
+++ b/src/dsp/sintable.h
@@ -34,6 +34,7 @@ struct SinTable
         SIN_FIFTH,
         SQUARISH,
         SAWISH,
+        TRIANGLE,
         SIN_OF_CUBED,
 
         TX2,
@@ -43,6 +44,11 @@ struct SinTable
         TX6,
         TX7,
         TX8,
+
+        SPIKY_TX2,
+        SPIKY_TX4,
+        SPIKY_TX6,
+        SPIKY_TX8,
 
         NUM_WAVEFORMS
     };

--- a/src/synth/patch.cpp
+++ b/src/synth/patch.cpp
@@ -76,6 +76,60 @@ float Patch::migrateParamValueFromVersion(Param *p, float value, uint32_t versio
                 return value + 1;
         }
     }
+
+    if (p->adhocFeatures & (uint64_t)Param::AdHocFeatureValues::WAVEFORM && version < 9)
+    {
+        /* version 8
+        *   SIN = 0, // these stream so you know....
+        SIN_FIFTH,
+        SQUARISH,
+        SAWISH,
+        SIN_OF_CUBED,
+
+        TX2,
+        TX3,
+        TX4,
+        TX5,
+        TX6,
+        TX7,
+        TX8,
+
+        version 9 and later
+
+        SIN = 0, // these stream so you know....
+        SIN_FIFTH,
+        SQUARISH,
+        SAWISH,
+        TRIANGLE,
+        SIN_OF_CUBED,
+
+        TX2,
+        TX3,
+        TX4,
+        TX5,
+        TX6,
+        TX7,
+        TX8,
+
+        SPIKY_TX2,
+        SPIKY_TX4,
+        SPIKY_TX6,
+        SPIKY_TX8,
+        */
+
+        // work around triangle
+        if (value > 3)
+            value = value + 1;
+
+        if (value == SinTable::TX2)
+            value = SinTable::SPIKY_TX2;
+        if (value == SinTable::TX4)
+            value = SinTable::SPIKY_TX4;
+        if (value == SinTable::TX6)
+            value = SinTable::SPIKY_TX6;
+        if (value == SinTable::TX8)
+            value = SinTable::SPIKY_TX8;
+    }
     return value;
 }
 

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -49,12 +49,13 @@ struct Param : pats::ParamBase
     {
         ENVTIME = 1 << 0,     // tag for ADSR envs we changed version 2-3
         TRIGGERMODE = 1 << 1, // trigger mode for when we nuked voice
+        WAVEFORM = 1 << 2,
     };
 };
 
 struct Patch : pats::PatchBase<Patch, Param>
 {
-    static constexpr uint32_t patchVersion{8};
+    static constexpr uint32_t patchVersion{9};
     static constexpr const char *id{"org.baconpaul.six-sines"};
 
     static constexpr uint32_t floatFlags{CLAP_PARAM_IS_AUTOMATABLE};
@@ -425,6 +426,7 @@ struct Patch : pats::PatchBase<Patch, Param>
                                                    {SinTable::WaveForm::SIN_FIFTH, "Sin^5 x"},
                                                    {SinTable::WaveForm::SQUARISH, "Squarish"},
                                                    {SinTable::WaveForm::SAWISH, "Sawish"},
+                                                   {SinTable::WaveForm::TRIANGLE, "Triangle"},
                                                    {SinTable::WaveForm::SIN_OF_CUBED, "Sin(x^3)"},
                                                    {SinTable::WaveForm::TX2, "TX 2"},
                                                    {SinTable::WaveForm::TX3, "TX 3"},
@@ -432,7 +434,12 @@ struct Patch : pats::PatchBase<Patch, Param>
                                                    {SinTable::WaveForm::TX5, "TX 5"},
                                                    {SinTable::WaveForm::TX6, "TX 6"},
                                                    {SinTable::WaveForm::TX7, "TX 7"},
-                                                   {SinTable::WaveForm::TX8, "TX 8"}})),
+                                                   {SinTable::WaveForm::TX8, "TX 8"},
+                                                   {SinTable::WaveForm::SPIKY_TX2, "Spiky TX 2"},
+                                                   {SinTable::WaveForm::SPIKY_TX4, "Spiky TX 4"},
+                                                   {SinTable::WaveForm::SPIKY_TX6, "Spiky TX 6"},
+                                                   {SinTable::WaveForm::SPIKY_TX8, "Spiky TX 8"}})),
+
               keyTrack(boolMd()
                            .withName(name(idx) + " Keytrack")
                            .withGroupName(name(idx))
@@ -473,6 +480,7 @@ struct Patch : pats::PatchBase<Patch, Param>
 
         {
             index = idx;
+            waveForm.adhocFeatures = Param::AdHocFeatureValues::WAVEFORM;
         }
 
         std::string name(int idx) const { return "Op " + std::to_string(idx + 1) + " Source"; }


### PR DESCRIPTION
TX81Z waveforms matched the manual sketches, but thats not what they actually did, so make it match the scoep and move the old ones to "Spiky" variants. Do patch migration for 1.0 patches which used this to use the Spiky form.

Closes #147