### PR TITLE
More side stuff. cleanup the zip readme

### DIFF
--- a/resources/ReadmeZip.txt
+++ b/resources/ReadmeZip.txt
@@ -1,19 +1,25 @@
-Six Sines - a small synth involving sine waves
-https://github.com/baconpaul/six-sines
+Six Sines
+Source: https://github.com/baconpaul/six-sines
+Manual: https://github.com/baconpaul/six-sines/blob/main/doc/manual.md
 
-Hi!
+Six Sines is a fun little synth exploring the possibilities of audio rate modulation.  Some people
+might call it an "FM" synth but its more PM and it also has AM. Surf the presets and twist the knobs
+and you'll get the idea.
 
-Enjoy six sines. You downloaded a zip of the plugins containing an executable, a clap, a vst3, and perhaps
-more.
+You've downloaded the zip file for either windows or linux (both have this same README) containing a clap,
+a vst3, and a standalone executable.
 
 To install the plugin you need to move the clap or vst3 to the appropriate place on your computer
 
-On windows files, move them to `c:\program files\common files\clap` or `vst3`
-On linx, it is usually ~/.clap, ~/.vst or /usr/lib/clap and /usr/lib/vst3
+On windows files, move them to `c:\program files\common files\clap` or `\vst3`
+On linux, it is usually ~/.clap, ~/.vst or /usr/lib/clap and /usr/lib/vst3
 
-You can read the manual once you launch the synth by clicking the patch selector and opening the manual
+To install just move the file into those locations using whatever mechanism you are happiest with
+in your environment.
 
-The six sines source code is released under the MIT license, but the final prodct contains dependencies meaning
-this release is released under the GNU General Public License, 3 or later
+If you have feedback ideas etc open a github issue or drop into the #baconpaul-sidequests channel
+of surge discord.
 
-and have fun!
+The six sines source code is released under the MIT license, but the final product contains GPL3 dependencies
+so this release is released under the GNU General Public License, 3 or later. You can read that license in the
+file License.txt included here.

--- a/src/dsp/op_source.h
+++ b/src/dsp/op_source.h
@@ -115,6 +115,10 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
             }
             else if (u2m == 2)
             {
+                operatorOutputsToMain = !(voiceValues.hasCenterVoice) || !voiceValues.isCenterVoice;
+            }
+            else if (u2m == 3)
+            {
                 operatorOutputsToMain = false;
             }
 
@@ -123,13 +127,18 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
             {
                 operatorOutputsToOp = !(voiceValues.hasCenterVoice) || voiceValues.isCenterVoice;
             }
+            else if (u2op == 2)
+            {
+                operatorOutputsToOp = !(voiceValues.hasCenterVoice) || !voiceValues.isCenterVoice;
+            }
         }
     }
 
     void resetPhaseOnly()
     {
         phase = 4 << 27;
-        if (voiceValues.phaseRandom)
+        unisonParticipatesTune = (int)(sourceNode.unisonParticipation.value) & 1;
+        if (voiceValues.phaseRandom && unisonParticipatesTune)
         {
             phase += monoValues.rng.unifU32() & ((1 << 27) - 1);
         }

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -486,23 +486,25 @@ struct Patch : pats::PatchBase<Patch, Param>
                                                                    {1, "Tuning Only"},
                                                                    {2, "Pan Only"},
                                                                    {3, "Tuning and Pan"}})),
-              unisonToMain(
-                  intMd()
-                      .withRange(0, 2)
-                      .withDefault(0)
-                      .withID(id(15, idx))
-                      .withName(name(idx) + " Unison Main Output")
-                      .withGroupName(name(idx))
-                      .withUnorderedMapFormatting(
-                          {{0, "All to Main"}, {1, "Center to Main"}, {2, "None to Main"}})),
+              unisonToMain(intMd()
+                               .withRange(0, 3)
+                               .withDefault(0)
+                               .withID(id(15, idx))
+                               .withName(name(idx) + " Unison Main Output")
+                               .withGroupName(name(idx))
+                               .withUnorderedMapFormatting({{0, "All to Main"},
+                                                            {1, "Center to Main"},
+                                                            {2, "Sides to Main"},
+                                                            {3, "None to Main"}})),
               unisonToOpOut(intMd()
-                                .withRange(0, 1)
+                                .withRange(0, 2)
                                 .withDefault(0)
                                 .withID(id(16, idx))
                                 .withName(name(idx) + " Unison Operator Output Output")
                                 .withGroupName(name(idx))
-                                .withUnorderedMapFormatting(
-                                    {{0, "All to Op Output"}, {1, "Center to Op Output"}})),
+                                .withUnorderedMapFormatting({{0, "All to Op Output"},
+                                                             {1, "Center to Op Output"},
+                                                             {2, "Sides to Op Output"}})),
 
               DAHDSRMixin(name(idx), id(100, idx), false), LFOMixin(name(idx), id(45, idx)),
               ModulationMixin(name(idx), id(150, idx)),

--- a/src/ui/source-sub-panel.cpp
+++ b/src/ui/source-sub-panel.cpp
@@ -288,11 +288,17 @@ void SourceSubPanel::showUnisonFeaturesMenu()
                   if (w)
                       w->editor.sendParamSetValue(u2mid, 1);
               });
-    p.addItem("No Voices to Main", true, u2m == 2,
+    p.addItem("Side Voices Only to Main", canCenter, u2m == 2,
               [w = juce::Component::SafePointer(this), u2mid]()
               {
                   if (w)
                       w->editor.sendParamSetValue(u2mid, 2);
+              });
+    p.addItem("No Voices to Main", true, u2m == 3,
+              [w = juce::Component::SafePointer(this), u2mid]()
+              {
+                  if (w)
+                      w->editor.sendParamSetValue(u2mid, 3);
               });
     p.addSeparator();
     auto u2o = (int)editor.patchCopy.sourceNodes[index].unisonToOpOut.value;
@@ -308,6 +314,12 @@ void SourceSubPanel::showUnisonFeaturesMenu()
               {
                   if (w)
                       w->editor.sendParamSetValue(u2oid, 1);
+              });
+    p.addItem("Side Voices Only to Op " + std::to_string(index + 1) + " Out", canCenter, u2o == 2,
+              [w = juce::Component::SafePointer(this), u2oid]()
+              {
+                  if (w)
+                      w->editor.sendParamSetValue(u2oid, 2);
               });
 
     p.showMenuAsync(juce::PopupMenu::Options().withParentComponent(&editor));


### PR DESCRIPTION
- Have a sides-only as well as center-only option
- If you skip tuning, skip random phase also in an operator Closes #182

- Improve the readme for the lin/win zips. And clean up their structure Closes #171