### PR TITLE
Fix keyboard handling in some windows VST3 contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 .DS_Store
 .idea/
+.vs/
 cmake-*/
 ignore/
 minst*.sh


### PR DESCRIPTION
This implements the JUCE sneaky bheind-the-scenes windows event hook in the clap juce shim, defacto making keyboard entry in live and s1 on windows not work.

This fixes it.

Closes #202
Closes #106