### PR TITLE
Low Frequency KeyTrack option

### DIFF
--- a/src/dsp/op_source.h
+++ b/src/dsp/op_source.h
@@ -46,8 +46,8 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
 
     bool keytrack{true};
     const float &ratio, &activeV, &envToRatio, &lfoToRatio, &envToRatioFine,
-        &lfoToRatioFine;                                          // in  frequency multiple
-    const float &waveForm, &kt, &ktv, &startPhase, &octTranspose; // in octaves;
+        &lfoToRatioFine; // in  frequency multiple
+    const float &waveForm, &kt, &ktv, &ktlo, &ktlov, &startPhase, &octTranspose; // in octaves;
     bool active{false};
     bool unisonParticipatesPan{true}, unisonParticipatesTune{true};
     bool operatorOutputsToMain{true}, operatorOutputsToOp{true};
@@ -64,6 +64,7 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
           LFOSupport(sn, mv), ModulationSupport(sn, this, mv, vv), ratio(sn.ratio),
           activeV(sn.active), envToRatio(sn.envToRatio), lfoToRatio(sn.lfoToRatio),
           waveForm(sn.waveForm), kt(sn.keyTrack), ktv(sn.keyTrackValue),
+          ktlo(sn.keyTrackValueIsLow), ktlov(sn.keyTrackLowFrequencyValue),
           startPhase(sn.startingPhase), octTranspose(sn.octTranspose),
           lfoToRatioFine(sn.lfoToRatioFine), envToRatioFine(sn.envToRatioFine)
     {
@@ -169,8 +170,15 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
         }
         else
         {
-            // Consciously do *not* retune absolute mode oscillators
-            baseFrequency = 440 * monoValues.twoToTheX.twoToThe(ktv / 12);
+            if (ktlo > 0.5)
+            {
+                baseFrequency = ktlov; // its just in hertz
+            }
+            else
+            {
+                // Consciously do *not* retune absolute mode oscillators
+                baseFrequency = 440 * monoValues.twoToTheX.twoToThe(ktv / 12);
+            }
         }
     }
 

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -498,6 +498,11 @@ struct Patch : pats::PatchBase<Patch, Param>
                            .withGroupName(name(idx))
                            .withID(id(6, idx))
                            .withDefault(true)),
+              keyTrackValueIsLow(boolMd()
+                                     .withName(name(idx) + " Keytrack Frequency is Low Frequency")
+                                     .withGroupName(name(idx))
+                                     .withID(id(17, idx))
+                                     .withDefault(false)),
               keyTrackValue(floatMd()
                                 .withName(name(idx) + " Absolute Frequency at Ratio=1")
                                 .withGroupName(name(idx))
@@ -505,6 +510,14 @@ struct Patch : pats::PatchBase<Patch, Param>
                                 .withRange(-70, 70)
                                 .withSemitoneZeroAt400Formatting()
                                 .withID(id(7, idx))),
+              keyTrackLowFrequencyValue(
+                  floatMd()
+                      .withName(name(idx) + " Keytrack Frequency at Ratio=1 (Low Frequency)")
+                      .withGroupName(name(idx))
+                      .withRange(0, 10)
+                      .withLinearScaleFormatting("Hz")
+                      .withID(id(18, idx))
+                      .withDefault(1)),
               startingPhase(floatMd()
                                 .withName(name(idx) + " Phase")
                                 .withGroupName(name(idx))
@@ -586,7 +599,7 @@ struct Patch : pats::PatchBase<Patch, Param>
 
         Param waveForm;
 
-        Param keyTrack, keyTrackValue;
+        Param keyTrack, keyTrackValue, keyTrackLowFrequencyValue, keyTrackValueIsLow;
 
         Param startingPhase, octTranspose;
 
@@ -596,11 +609,22 @@ struct Patch : pats::PatchBase<Patch, Param>
 
         std::vector<Param *> params()
         {
-            std::vector<Param *> res{&ratio,          &active,         &envToRatio,
-                                     &lfoToRatio,     &waveForm,       &keyTrack,
-                                     &keyTrackValue,  &startingPhase,  &octTranspose,
-                                     &envToRatioFine, &lfoToRatioFine, &unisonParticipation,
-                                     &unisonToMain,   &unisonToOpOut};
+            std::vector<Param *> res{&ratio,
+                                     &active,
+                                     &envToRatio,
+                                     &lfoToRatio,
+                                     &waveForm,
+                                     &keyTrack,
+                                     &keyTrackLowFrequencyValue,
+                                     &keyTrackValueIsLow,
+                                     &keyTrackValue,
+                                     &startingPhase,
+                                     &octTranspose,
+                                     &envToRatioFine,
+                                     &lfoToRatioFine,
+                                     &unisonParticipation,
+                                     &unisonToMain,
+                                     &unisonToOpOut};
             for (int i = 0; i < numModsPer; ++i)
                 res.push_back(&modtarget[i]);
             appendDAHDSRParams(res);

--- a/src/ui/source-sub-panel.h
+++ b/src/ui/source-sub-panel.h
@@ -67,11 +67,16 @@ struct SourceSubPanel : juce::Component,
     std::unique_ptr<jcmp::ToggleButton> keyTrack;
     std::unique_ptr<PatchDiscrete> keyTrackD;
 
+    std::unique_ptr<jcmp::ToggleButton> keyTrackLow;
+    std::unique_ptr<PatchDiscrete> keyTrackLowD;
+
     std::unique_ptr<jcmp::TextPushButton> unisonBehaviorB;
 
     std::unique_ptr<jcmp::HSliderFilled> keyTrackValue;
     std::unique_ptr<PatchContinuous> keyTrackValueD;
-    std::unique_ptr<jcmp::Label> keyTrackValueLL;
+
+    std::unique_ptr<jcmp::HSliderFilled> keyTrackLowValue;
+    std::unique_ptr<PatchContinuous::cubic_t> keyTrackLowValueD;
 
     std::unique_ptr<jcmp::HSliderFilled> startingPhase;
     std::unique_ptr<PatchContinuous> startingPhaseD;


### PR DESCRIPTION
Keytrack now has a toggle to either be in the
audible (midi keybed) or low frequency (0-10hz)
range, with the slider adjusting accordingly.

Closes #203