### PR TITLE
Move to paramRescan model on patch load

### DIFF
--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -306,7 +306,8 @@ struct Synth
             UPDATE_VU,
             UPDATE_VOICE_COUNT,
             SET_PATCH_NAME,
-            SET_PATCH_DIRTY_STATE
+            SET_PATCH_DIRTY_STATE,
+            DO_PARAM_RESCAN
         } action;
         uint32_t paramId{0};
         float value{0}, value2{0};
@@ -318,12 +319,14 @@ struct Synth
         {
             REQUEST_REFRESH,
             SET_PARAM,
+            SET_PARAM_WITHOUT_NOTIFYING,
             BEGIN_EDIT,
             END_EDIT,
             STOP_AUDIO,
             START_AUDIO,
             SEND_PATCH_NAME,
             SEND_PATCH_IS_CLEAN,
+            SEND_REQUEST_RESCAN,
             EDITOR_ATTACH_DETATCH, // paramid is true for attach and false for detach
             PANIC_STOP_VOICES
         } action;

--- a/src/ui/six-sines-editor.h
+++ b/src/ui/six-sines-editor.h
@@ -74,6 +74,7 @@ struct SixSinesEditor : jcmp::WindowPanel
     std::unique_ptr<juce::Timer> idleTimer;
 
     std::unique_ptr<jcmp::NamedPanel> singlePanel;
+    void doSinglePanelHamburger();
 
     std::unique_ptr<MainPanel> mainPanel;
     std::unique_ptr<MainSubPanel> mainSubPanel;


### PR DESCRIPTION
so basically on patch load you ask for a rescan both in loadState and in the preset manager loader, which means we don't have to wrap around begin/end anymore, which makes live less twicthy, but also threw up a problem in the clap wrapper for auv2, fixed here