### PR TITLE
Dirty on daw save; and also sample rate on re-open

### DIFF
--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -730,6 +730,8 @@ void Synth::pushFullUIRefresh()
     }
     audioToUi.push({AudioToUIMsg::SET_PATCH_NAME, 0, 0, 0, patch.name});
     audioToUi.push({AudioToUIMsg::SET_PATCH_DIRTY_STATE, patch.dirty});
+    audioToUi.push(
+        {AudioToUIMsg::SEND_SAMPLE_RATE, 0, (float)hostSampleRate, (float)engineSampleRate});
 }
 
 } // namespace baconpaul::six_sines

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -364,6 +364,8 @@ struct Synth
             cc->nextLag = nullptr;
             cc->prevLag = nullptr;
         }
+        patch.dirty = false;
+        doFullRefresh = true;
     }
 
     void pushFullUIRefresh();


### PR DESCRIPTION
- If you save in a DAW context ,the dirty flag gets saved. Closes #216
- The sample rate didn't display properly when re-opening the UI.