### PR TITLE
Add a Ratio (Fine) target; name LFO Atten as such

### DIFF
--- a/src/dsp/op_source.h
+++ b/src/dsp/op_source.h
@@ -331,6 +331,9 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
                     case Patch::SourceNode::DIRECT:
                         ratioMod += d * *sourcePointers[i] * 2;
                         break;
+                    case Patch::SourceNode::DIRECT_FINE:
+                        ratioMod += d * *sourcePointers[i] * 2.0 / 12.0;
+                        break;
                     case Patch::SourceNode::STARTING_PHASE:
                         phaseMod += d * *sourcePointers[i];
                         break;

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -415,6 +415,7 @@ struct Patch : pats::PatchBase<Patch, Param>
             SKIP = -1,
             NONE = 0,
             DIRECT = 10,
+            DIRECT_FINE = 11,
             STARTING_PHASE = 15,
             ENV_DEPTH_ATTEN = 20,
             LFO_DEPTH_ATTEN = 30,
@@ -424,9 +425,10 @@ struct Patch : pats::PatchBase<Patch, Param>
             {TargetID::NONE, "Off"},
             {TargetID::SKIP, ""},
             {TargetID::DIRECT, "Ratio"},
+            {TargetID::DIRECT_FINE, "Ratio (Fine)"},
             {TargetID::STARTING_PHASE, "Phase"},
-            {TargetID::ENV_DEPTH_ATTEN, "Env Sens"},
-            {TargetID::LFO_DEPTH_ATTEN, "LFO Sens"},
+            {TargetID::ENV_DEPTH_ATTEN, "Env Atten"},
+            {TargetID::LFO_DEPTH_ATTEN, "LFO Atten"},
 
         };
 


### PR DESCRIPTION
- add a mod target in op soruce for Ratio (Fine). Closes #233
- rename LFO Sens and Env Sens as LFO Atten and Env Atten to be consistent with other nodes