### PR TITLE
Fix an embarrasing temposync bug

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -25,6 +25,8 @@ do sound design in six sines.
 
 - [Video One - Six Sines First Steps](https://youtu.be/fP4wNFigUt4?si=uKoq_MVoYYqzQkN3)
 - [Video Two - Exploring AM](https://youtu.be/JU1Yzfb5U_c?si=lyaKbKRye48EvmSz)
+- [Video Three - FM and AM](https://www.youtube.com/watch?v=X7RTZz2G2ig)
+- [Video Four - Making a simple drumpset](https://www.youtube.com/watch?v=HnpFRSw-QBc)
 
 Thanks so much for these, Taron! They are great!
 

--- a/src/dsp/node_support.h
+++ b/src/dsp/node_support.h
@@ -316,7 +316,7 @@ template <typename T, bool needsSmoothing = true> struct LFOSupport
         }
 
         lfo.process_block(rate + lfoRateMod, std::clamp(lfoDeform + lfoDeformMod, -1.f, 1.f), shape,
-                          false, monoValues.tempoSyncRatio);
+                          false, tempoSync ? monoValues.tempoSyncRatio : 1.0);
 
         if (doSmooth)
         {


### PR DESCRIPTION
I only *snapped* if temposync was on but always *applied* temposync factor to lfos

Closes #247 