### PR TITLE
A small performance improvement

### DIFF
--- a/src/dsp/matrix_node.h
+++ b/src/dsp/matrix_node.h
@@ -126,20 +126,6 @@ struct MatrixNodeFrom : public EnvelopeSupport<Patch::MatrixNode>,
             {
                 onto.rmLevel[i] += modlev[i] * (from.output[i] - 1.0);
             }
-#if OLD_WAY
-            mech::mul_block<blockSize>(modlev, from.output, mod);
-
-            if (onto.rmAssigned)
-            {
-                mech::accumulate_from_to<blockSize>(mod, onto.rmLevel);
-            }
-            else
-            {
-                onto.rmAssigned = true;
-
-                mech::copy_from_to<blockSize>(mod, onto.rmLevel);
-            }
-#endif
         }
         else if (modMode == 2)
         {

--- a/src/synth/matrix_index.h
+++ b/src/synth/matrix_index.h
@@ -39,17 +39,9 @@ struct MatrixIndex
             {
                 for (int s = 0; s < t; ++s)
                 {
-                    sourceTable[idx++] = s;
-                }
-            }
-        }
-        {
-            int idx{0};
-            for (int t = 1; t < numOps; ++t)
-            {
-                for (int s = 0; s < t; ++s)
-                {
-                    targetTable[idx++] = t;
+                    sourceTable[idx] = s;
+                    targetTable[idx] = t;
+                    idx++;
                 }
             }
         }
@@ -66,7 +58,6 @@ struct MatrixIndex
             auto s = sourceTable[i];
             auto t = targetTable[i];
             positionMatrix[s][t] = i;
-            SXSNLOG("At " << i << " source " << s << " target " << t);
         }
         return tablesInitialized;
     }

--- a/src/synth/matrix_index.h
+++ b/src/synth/matrix_index.h
@@ -23,12 +23,16 @@ namespace baconpaul::six_sines
 {
 struct MatrixIndex
 {
-    static size_t sourceIndexAt(size_t position)
+    static inline size_t sourceTable[matrixSize];
+    static inline size_t targetTable[matrixSize];
+    static inline size_t positionMatrix[numOps][numOps];
+
+    static inline bool tablesInitialized{false};
+    static bool initialize()
     {
-        assert(position < matrixSize);
-        static size_t sourceTable[matrixSize];
-        static bool sourceTableInit{false};
-        if (!sourceTableInit)
+        if (tablesInitialized)
+            return tablesInitialized;
+        tablesInitialized = true;
         {
             int idx{0};
             for (int t = 1; t < numOps; ++t)
@@ -38,17 +42,7 @@ struct MatrixIndex
                     sourceTable[idx++] = s;
                 }
             }
-            sourceTableInit = true;
         }
-        return sourceTable[position];
-    }
-
-    static size_t targetIndexAt(size_t position)
-    {
-        assert(position < matrixSize);
-        static size_t targetTable[matrixSize];
-        static bool targetTableInit{false};
-        if (!targetTableInit)
         {
             int idx{0};
             for (int t = 1; t < numOps; ++t)
@@ -58,34 +52,42 @@ struct MatrixIndex
                     targetTable[idx++] = t;
                 }
             }
-            targetTableInit = true;
         }
+
+        for (int i = 0; i < numOps; ++i)
+        {
+            for (int j = 0; j < numOps; ++j)
+            {
+                positionMatrix[i][j] = matrixSize + 1;
+            }
+        }
+        for (int i = 0; i < matrixSize; ++i)
+        {
+            auto s = sourceTable[i];
+            auto t = targetTable[i];
+            positionMatrix[s][t] = i;
+            SXSNLOG("At " << i << " source " << s << " target " << t);
+        }
+        return tablesInitialized;
+    }
+
+    static inline size_t sourceIndexAt(size_t position)
+    {
+        assert(tablesInitialized);
+        assert(position < matrixSize);
+        return sourceTable[position];
+    }
+
+    static inline size_t targetIndexAt(size_t position)
+    {
+        assert(tablesInitialized);
+        assert(position < matrixSize);
         return targetTable[position];
     }
 
-    static size_t positionForSourceTarget(size_t source, size_t target)
+    static inline size_t positionForSourceTarget(size_t source, size_t target)
     {
-        static size_t positionMatrix[numOps][numOps];
-        static bool matrixInit{false};
-
-        if (!matrixInit)
-        {
-            for (int i = 0; i < numOps; ++i)
-            {
-                for (int j = 0; j < numOps; ++j)
-                {
-                    positionMatrix[i][j] = matrixSize + 1;
-                }
-            }
-            for (int i = 0; i < matrixSize; ++i)
-            {
-                auto s = sourceIndexAt(i);
-                auto t = targetIndexAt(i);
-                positionMatrix[s][t] = i;
-            }
-            matrixInit = true;
-        }
-
+        assert(tablesInitialized);
         assert(positionMatrix[source][target] < matrixSize);
 
         return positionMatrix[source][target];

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -92,6 +92,7 @@ struct Patch : pats::PatchBase<Patch, Param>
           macroNodes(scpu::make_array_bind_first_index<MacroNode, numMacros>()), fineTuneMod(),
           mainPanMod()
     {
+        MatrixIndex::initialize();
         auto pushParams = [this](auto &from) { this->pushMultipleParams(from.params()); };
 
         pushParams(output);

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -46,6 +46,7 @@ struct Synth
     float output alignas(16)[2 * (1 + numOps)][blockSize];
 
     bool isMultiOut{false};
+    bool isTableInitialized{MatrixIndex::initialize()}; // this forces this init before other ctors
 
     SampleRateStrategy sampleRateStrategy{SampleRateStrategy::SR_110120};
     ResamplerEngine resamplerEngine{ResamplerEngine::SRC_FAST};

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -175,6 +175,7 @@ SixSinesEditor::~SixSinesEditor()
 {
     mainToAudio.push({Synth::MainToAudioMsg::EDITOR_ATTACH_DETATCH, false});
     idleTimer->stopTimer();
+    setLookAndFeel(nullptr);
 }
 
 void SixSinesEditor::idle()


### PR DESCRIPTION
A small performance improvement in the frequent lookup of matrix nodes, which was burning 2-3% of cycle time in some profile cases. Move it to a non-inline initialize and init-early then the getters just get.