### PR TITLE
Fix the one part where I dropped UTF16 path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,11 @@ if (${BUILD_SINGLE_ONLY})
     )
 endif()
 
+if (WIN32)
+    message(STATUS "Activating wchar presets")
+    target_compile_definitions(${PROJECT_NAME}-impl PUBLIC USE_WCHAR_PRESET=1)
+endif()
+
 target_link_libraries(${PROJECT_NAME}-impl PUBLIC
         clap
 )

--- a/src/presets/preset-manager.cpp
+++ b/src/presets/preset-manager.cpp
@@ -143,9 +143,12 @@ void PresetManager::rescanUserPresets()
     }
 }
 
-void PresetManager::saveUserPresetDirect(Patch &patch, const fs::path &pt)
+
+#if USE_WCHAR_PRESET
+void PresetManager::saveUserPresetDirect(Patch &patch, const wchar_t *fname)
 {
-    std::ofstream ofs(pt);
+    std::ofstream ofs(fname);
+
     if (ofs.is_open())
     {
         ofs << patch.toState();
@@ -153,6 +156,19 @@ void PresetManager::saveUserPresetDirect(Patch &patch, const fs::path &pt)
     ofs.close();
     rescanUserPresets();
 }
+#else
+void PresetManager::saveUserPresetDirect(Patch &patch, const fs::path &pt)
+{
+    std::ofstream ofs(pt);
+
+    if (ofs.is_open())
+    {
+        ofs << patch.toState();
+    }
+    ofs.close();
+    rescanUserPresets();
+}
+#endif
 
 void PresetManager::loadUserPresetDirect(Patch &patch, Synth::mainToAudioQueue_T &mainToAudio,
                                          const fs::path &p)

--- a/src/presets/preset-manager.h
+++ b/src/presets/preset-manager.h
@@ -47,7 +47,11 @@ struct PresetManager
     void loadFactoryPreset(Patch &, Synth::mainToAudioQueue_T &, const std::string &cat,
                            const std::string &pat);
 
+#if USE_WCHAR_PRESET
+    void saveUserPresetDirect(Patch &, const wchar_t *utf8path);
+#else
     void saveUserPresetDirect(Patch &, const fs::path &p);
+#endif
 
     std::function<void(const std::string &)> onPresetLoaded{nullptr};
 

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -773,10 +773,16 @@ void SixSinesEditor::doSavePatch()
                                  {
                                      return;
                                  }
-                                 auto pn = fs::path{result[0].getFullPathName().toStdString()};
+                                 auto pn =
+                                     fs::path{result[0].getFullPathName().toStdString()};
                                  w->setPatchNameTo(pn.filename().replace_extension("").u8string());
 
+#if USE_WCHAR_PRESET
+                                 w->presetManager->saveUserPresetDirect(w->patchCopy, result[0].getFullPathName().toUTF16());
+#else
                                  w->presetManager->saveUserPresetDirect(w->patchCopy, pn);
+#endif
+
                                  w->presetDataBinding->setDirtyState(false);
                                  w->repaint();
                              });


### PR DESCRIPTION
basically the juce callback gives me a non-type-protected string so my fs::path care goes blammo. So windows users with utf16 names didn't work for save, just everything else