### PR TITLE
LFO Rate; Tooltips; Wrapper Update

### DIFF
--- a/src/presets/preset-manager.cpp
+++ b/src/presets/preset-manager.cpp
@@ -143,7 +143,6 @@ void PresetManager::rescanUserPresets()
     }
 }
 
-
 #if USE_WCHAR_PRESET
 void PresetManager::saveUserPresetDirect(Patch &patch, const wchar_t *fname)
 {

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -143,7 +143,7 @@ struct Patch : pats::PatchBase<Patch, Param>
     {
         LFOMixin(const std::string name, int id0)
             : lfoRate(floatMd()
-                          .asLfoRate()
+                          .asLfoRate(-7, 11)
                           .withName(name + " LFO Rate")
                           .withGroupName(name)
                           .withDefault(0)

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -356,7 +356,7 @@ struct Synth
         if (lagHandler.active)
             lagHandler.instantlySnap();
 
-        for (auto &p: paramLagSet)
+        for (auto &p : paramLagSet)
         {
             p.lag.snapToTarget();
             p.value = p.lag.v;

--- a/src/ui/patch-data-bindings.h
+++ b/src/ui/patch-data-bindings.h
@@ -215,6 +215,14 @@ void createComponent(SixSinesEditor &e, P &panel, const Param &parm, std::unique
             e.hideTooltip();
         }
     };
+
+    cm->onIdleHover = [&e, &cm, &pc]()
+    {
+        e.updateTooltip(pc.get());
+        e.showTooltipOn(cm.get());
+    };
+    cm->onIdleHoverEnd = [&e]() { e.hideTooltip(); };
+
     cm->setSource(pc.get());
     sst::jucegui::component_adapters::setClapParamId(cm.get(), id);
     e.componentByID[id] = juce::Component::SafePointer<juce::Component>(cm.get());
@@ -251,6 +259,12 @@ void createRescaledComponent(SixSinesEditor &e, P &panel, const Param &parm, std
         e.mainToAudio.push({Synth::MainToAudioMsg::Action::END_EDIT, id});
         e.hideTooltip();
     };
+    cm->onIdleHover = [&e, &cm, &rc]()
+    {
+        e.updateTooltip(rc.get());
+        e.showTooltipOn(cm.get());
+    };
+    cm->onIdleHoverEnd = [&e]() { e.hideTooltip(); };
     cm->setSource(rc.get());
     sst::jucegui::component_adapters::setClapParamId(cm.get(), id);
 

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -773,12 +773,12 @@ void SixSinesEditor::doSavePatch()
                                  {
                                      return;
                                  }
-                                 auto pn =
-                                     fs::path{result[0].getFullPathName().toStdString()};
+                                 auto pn = fs::path{result[0].getFullPathName().toStdString()};
                                  w->setPatchNameTo(pn.filename().replace_extension("").u8string());
 
 #if USE_WCHAR_PRESET
-                                 w->presetManager->saveUserPresetDirect(w->patchCopy, result[0].getFullPathName().toUTF16());
+                                 w->presetManager->saveUserPresetDirect(
+                                     w->patchCopy, result[0].getFullPathName().toUTF16());
 #else
                                  w->presetManager->saveUserPresetDirect(w->patchCopy, pn);
 #endif


### PR DESCRIPTION
1. Clap Wrapper to next / v0.12.0 commit
2. LFO Rate up to 2048, since we have a higher nyquist. Closes #276
3. Turn on tooltips on hover. Closes #275