### PR TITLE
Smooth mod matrix vel, not just sens vel

### DIFF
--- a/src/dsp/node_support.h
+++ b/src/dsp/node_support.h
@@ -486,7 +486,7 @@ template <typename Bundle, typename Node> struct ModulationSupport
             break;
 
         case ModMatrixConfig::Source::VELOCITY:
-            sourcePointers[which] = &voiceValues.velocity;
+            sourcePointers[which] = &voiceValues.velocityLag.v;
             break;
         case ModMatrixConfig::Source::RELEASE_VELOCITY:
             sourcePointers[which] = &voiceValues.releaseVelocity;

--- a/src/synth/voice.cpp
+++ b/src/synth/voice.cpp
@@ -48,6 +48,9 @@ Voice::Voice(const Patch &p, MonoValues &mv)
 
 void Voice::attack()
 {
+    voiceValues.velocityLag.snapTo(voiceValues.velocity);
+    voiceValues.velocityLag.setRateInMilliseconds(10, monoValues.sr.sampleRate, 1.0 / blockSize);
+
     out.attack();
     for (auto &n : mixerNode)
         n.attack();
@@ -90,6 +93,9 @@ void Voice::renderBlock()
     static constexpr float octFac[7] = {1.0 / 8.0, 1.0 / 4.0, 1.0 / 2.0, 1.0, 2.0, 4.0, 8.0};
 
     auto baseFreq = monoValues.tuningProvider.note_to_pitch(retuneKey - 69) * 440.0;
+
+    voiceValues.velocityLag.setTarget(voiceValues.velocity);
+    voiceValues.velocityLag.process();
 
     for (int i = 0; i < numOps; ++i)
     {

--- a/src/synth/voice_values.h
+++ b/src/synth/voice_values.h
@@ -18,6 +18,7 @@
 
 #include <sst/basic-blocks/tables/EqualTuningProvider.h>
 #include <sst/basic-blocks/tables/TwoToTheXProvider.h>
+#include "sst/basic-blocks/dsp/Lag.h"
 
 struct MTSClient;
 
@@ -61,6 +62,8 @@ struct VoiceValues
     float uniPMScale{0.f}; // -1 to 1 for unison field
     bool hasCenterVoice{false}, isCenterVoice{false};
     bool phaseRandom{false}, rephaseOnRetrigger{false};
+
+    sst::basic_blocks::dsp::OnePoleLag<float, false> velocityLag;
 
   private:
     bool gatedV{false};


### PR DESCRIPTION
The velocity for the retrigger in velocity sensitive mode was smoothed with a short one pole, but if you used velocity in the mod matrix, no such smoothing existed, leading to velcity sensitivty mod of amplitude and direct mod of amplitude clicking or not.

Fix that by moving the velocity lagger into voice values and having it be voice wide

Addresses #281