### PR TITLE
On STOP_AUDIO (and thus patch reload) reset the ui lag handler

### DIFF
--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -605,6 +605,8 @@ void Synth::processUIQueue(const clap_output_events_t *outq)
         break;
         case MainToAudioMsg::STOP_AUDIO:
         {
+            if (lagHandler.active)
+                lagHandler.instantlySnap();
             voiceManager->allSoundsOff();
             audioRunning = false;
         }


### PR DESCRIPTION
since otherwise the lag handler would subsequently override the patch load in some cases.

Since the load path always calls STOP_AUDIO this is the right spot

Closes #286