### PR TITLE
Add a main thread request rescan

### DIFF
--- a/src/clap/six-sines-clap.cpp
+++ b/src/clap/six-sines-clap.cpp
@@ -74,7 +74,10 @@ struct SixSinesClap : public plugHelper_t, sst::clap_juce_shim::EditorProvider
         return true;
     }
 
-    void onMainThread() noexcept override {}
+    void onMainThread() noexcept override
+    {
+        engine->onMainThread();
+    }
 
     bool implementsAudioPorts() const noexcept override { return true; }
     uint32_t audioPortsCount(bool isInput) const noexcept override

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -381,6 +381,9 @@ struct Synth
         }
     }
 
+    std::atomic<bool> onMainRescanParams{false};
+    void onMainThread();
+
     void reapplyControlSettings();
     void resetSoloState();
 


### PR DESCRIPTION
In the event the audio thread doesn't pick up the rescan or the request flush happens before the enine events are applied, this will guarantee a rescan

I can *probably* remove DO_PARAM_RESCAN as a result of this change but lets do that separately and later