### PR TITLE
Upgrade voice manager; reactivate note ids

### DIFF
--- a/src/clap/six-sines-clap.cpp
+++ b/src/clap/six-sines-clap.cpp
@@ -232,7 +232,7 @@ struct SixSinesClap : public plugHelper_t, sst::clap_juce_shim::EditorProvider
             {
                 auto nevt = reinterpret_cast<const clap_event_note *>(nextEvent);
                 auto nid = nevt->note_id;
-                nid = -1; // see issue #168
+                // nid = -1;
                 vm->processNoteOffEvent(nevt->port_index, nevt->channel, nevt->key, nid,
                                         nevt->velocity);
             }

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -129,6 +129,7 @@ struct Synth
 
         void endVoiceCreationTransaction(uint16_t, uint16_t, uint16_t, int32_t, float) {}
 
+        void discardHostVoice(int32_t vid) {}
         void terminateVoice(Voice *voice)
         {
             voice->voiceValues.setGated(false);
@@ -241,6 +242,7 @@ struct Synth
             }
         }
         void setVoicePolyphonicParameterModulation(Voice *, uint32_t, double) {}
+        void setVoiceMonophonicParameterModulation(Voice *, uint32_t, double) {}
         void setPolyphonicAftertouch(Voice *v, int8_t a) { v->voiceValues.polyAt = a / 127.0; }
 
         void setVoiceMIDIMPEChannelPitchBend(Voice *v, uint16_t b)


### PR DESCRIPTION
This means note expressions now work as expected with stacked notes in the clap, for instance.

Closes #174
Closes #221