### PR TITLE
Call guiSetSize as well as guiReqestResize

### DIFF
--- a/src/clap/six-sines-clap.cpp
+++ b/src/clap/six-sines-clap.cpp
@@ -388,7 +388,10 @@ struct SixSinesClap : public plugHelper_t, sst::clap_juce_shim::EditorProvider
         {
             if (_host.canUseGui() && clapJuceShim->isEditorAttached())
             {
+                // SXSNLOG("onZoomChanged " << f);
                 auto s = f * clapJuceShim->getGuiScale();
+                guiSetSize(baconpaul::six_sines::ui::SixSinesEditor::edWidth * s,
+                           baconpaul::six_sines::ui::SixSinesEditor::edHeight * s);
                 _host.guiRequestResize(baconpaul::six_sines::ui::SixSinesEditor::edWidth * s,
                                        baconpaul::six_sines::ui::SixSinesEditor::edHeight * s);
             }
@@ -396,6 +399,7 @@ struct SixSinesClap : public plugHelper_t, sst::clap_juce_shim::EditorProvider
 
         onShow = [e = res.get()]()
         {
+            // SXSNLOG("onShow with zoom factor " << e->zoomFactor);
             e->setZoomFactor(e->zoomFactor);
             return true;
         };


### PR DESCRIPTION
there's no requirement in the spec that _host.guiRequestResize call guiSetSize, and on Reaper on Windows, thats obeyed. So that meant six sines didn't work proerply on reaper in windows at non-100% zoom.

Closes #208