### PR TITLE
Implement preset discovery (using REAPER dev as a test)

### DIFF
--- a/src/clap/six-sines-clap-entry-impl.cpp
+++ b/src/clap/six-sines-clap-entry-impl.cpp
@@ -178,7 +178,7 @@ const void *get_factory(const char *factory_id)
 
     {
         // Uncomment this to try the preset discovery
-        // return sixSinesPresetDiscoveryFactory();
+        return sixSinesPresetDiscoveryFactory();
     }
     return nullptr;
 }

--- a/src/dsp/matrix_node.h
+++ b/src/dsp/matrix_node.h
@@ -248,7 +248,7 @@ struct MatrixNodeSelf : EnvelopeSupport<Patch::SelfNode>,
     MatrixNodeSelf(const Patch::SelfNode &sn, OpSource &on, MonoValues &mv, const VoiceValues &vv)
         : selfNode(sn), monoValues(mv), voiceValues(vv), onto(on), fbBase(sn.fbLevel),
           lfoToFB(sn.lfoToFB), activeV(sn.active), envToFB(sn.envToFB), overdriveV(sn.overdrive),
-          EnvelopeSupport(sn, mv, vv), LFOSupport(sn, mv), ModulationSupport(sn, this, mv, vv){};
+          EnvelopeSupport(sn, mv, vv), LFOSupport(sn, mv), ModulationSupport(sn, this, mv, vv) {};
     bool active{true}, lfoMul{false};
     float overdriveFactor{1.0};
 

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -580,10 +580,9 @@ void SixSinesEditor::showPresetPopup()
             {
                 noExt = noExt.substr(0, ps);
             }
-            em.addItem(noExt,
-                       [cat = c, pat = e, this]() {
-                           this->presetManager->loadFactoryPreset(patchCopy, mainToAudio, cat, pat);
-                       });
+            em.addItem(
+                noExt, [cat = c, pat = e, this]()
+                { this->presetManager->loadFactoryPreset(patchCopy, mainToAudio, cat, pat); });
         }
         f.addSubMenu(c, em);
     }


### PR DESCRIPTION
Now that REAPER dev has PLUGIN and FILE support I can turn on the preset discovery in six sines.

Todo still: This makes it clear the preset manager is on the wrong thing. It should be on engine not on editor and editor should keep a ref.

But this works with a temporary for now.