### PR TITLE
Add design mode helpers for patch editing

### DIFF
--- a/src/dsp/matrix_node.h
+++ b/src/dsp/matrix_node.h
@@ -61,7 +61,7 @@ struct MatrixNodeFrom : public EnvelopeSupport<Patch::MatrixNode>,
         envResetMod();
         lfoResetMod();
 
-        active = activeV > 0.5;
+        active = activeV > 0.5 || monoValues.designModeRunAll;
 
         modMode = (int)std::round(modmodeV);
         rmScale = (int)std::round(rmScaleV);
@@ -258,7 +258,7 @@ struct MatrixNodeSelf : EnvelopeSupport<Patch::SelfNode>,
         envResetMod();
         lfoResetMod();
 
-        active = activeV > 0.5;
+        active = activeV > 0.5 || monoValues.designModeRunAll;
         if (active)
         {
             bindModulation();
@@ -400,7 +400,7 @@ struct MixerNode : EnvelopeSupport<Patch::MixerNode>,
         envResetMod();
         lfoResetMod();
 
-        active = activeF > 0.5;
+        active = activeF > 0.5 || monoValues.designModeRunAll;
         memset(output, 0, sizeof(output));
         if (active)
         {

--- a/src/dsp/op_source.h
+++ b/src/dsp/op_source.h
@@ -175,7 +175,7 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
 
     void clearOutputs() { memset(output, 0, sizeof(output)); }
 
-    void snapActive() { active = activeV > 0.5; }
+    void snapActive() { active = activeV > 0.5 || monoValues.designModeRunAll; }
 
     float baseFrequency{0};
     void setBaseFrequency(float freq, float octFac)

--- a/src/synth/mono_values.h
+++ b/src/synth/mono_values.h
@@ -63,6 +63,7 @@ struct MonoValues
     float channelAT{0.f};
 
     bool attackFloorOnRetrig{true};
+    bool designModeRunAll{false};
 
     std::array<float *, numMacros> macroPtr;
 

--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -677,6 +677,12 @@ void Synth::processUIQueue(const clap_output_events_t *outq)
             voiceManager->allSoundsOff();
         }
         break;
+        case MainToAudioMsg::SET_DESIGN_MODE_RUN_ALL:
+        {
+            monoValues.designModeRunAll = uiM->value > 0.5;
+            voiceManager->allSoundsOff();
+        }
+        break;
         }
         uiM = mainToAudio.pop();
     }

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -338,7 +338,8 @@ struct Synth
             SEND_REQUEST_RESCAN,
             EDITOR_ATTACH_DETATCH, // paramid is true for attach and false for detach
             SEND_PREP_FOR_STREAM,
-            PANIC_STOP_VOICES
+            PANIC_STOP_VOICES,
+            SET_DESIGN_MODE_RUN_ALL
         } action;
         uint32_t paramId{0};
         float value{0};

--- a/src/ui/matrix-panel.cpp
+++ b/src/ui/matrix-panel.cpp
@@ -36,6 +36,11 @@ MatrixPanel::MatrixPanel(SixSinesEditor &e) : jcmp::NamedPanel("Matrix"), HasEdi
         Spower[i]->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::GLYPH);
         Spower[i]->setGlyph(sst::jucegui::components::GlyphPainter::POWER);
         addAndMakeVisible(*Spower[i]);
+        SpowerData[i]->onGuiSetValue = [w = juce::Component::SafePointer(this)]()
+        {
+            if (w)
+                w->optionalAllSoundsOffOnToggle();
+        };
 
         Slabels[i] = std::make_unique<jcmp::Label>();
         Slabels[i]->setText("Op " + std::to_string(i + 1) + " " + u8"\U000021A9");
@@ -47,6 +52,7 @@ MatrixPanel::MatrixPanel(SixSinesEditor &e) : jcmp::NamedPanel("Matrix"), HasEdi
                 return;
             w->editor.setAndSendParamValue(w->editor.patchCopy.selfNodes[i].active, true);
             w->editor.setAndSendParamValue(w->editor.patchCopy.sourceNodes[i].active, true);
+            w->optionalAllSoundsOffOnToggle();
             w->repaint();
         };
         sst::jucegui::component_adapters::setTraversalId(Spower[i].get(), i * 50 + 47);
@@ -64,6 +70,11 @@ MatrixPanel::MatrixPanel(SixSinesEditor &e) : jcmp::NamedPanel("Matrix"), HasEdi
         Mpower[i]->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::GLYPH);
         Mpower[i]->setGlyph(sst::jucegui::components::GlyphPainter::POWER);
         addAndMakeVisible(*Mpower[i]);
+        MpowerData[i]->onGuiSetValue = [w = juce::Component::SafePointer(this)]()
+        {
+            if (w)
+                w->optionalAllSoundsOffOnToggle();
+        };
 
         MmodMode[i] = std::make_unique<sst::jucegui::components::TextPushButton>();
         MmodMode[i]->setLabel(std::to_string(i));
@@ -96,6 +107,7 @@ MatrixPanel::MatrixPanel(SixSinesEditor &e) : jcmp::NamedPanel("Matrix"), HasEdi
                                            true);
             w->editor.setAndSendParamValue(w->editor.patchCopy.sourceNodes[si].active.meta.id, true,
                                            true);
+            w->optionalAllSoundsOffOnToggle();
             w->repaint();
         };
 

--- a/src/ui/mixer-panel.cpp
+++ b/src/ui/mixer-panel.cpp
@@ -36,6 +36,11 @@ MixerPanel::MixerPanel(SixSinesEditor &e) : jcmp::NamedPanel("Mixer"), HasEditor
         power[i]->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::GLYPH);
         power[i]->setGlyph(sst::jucegui::components::GlyphPainter::POWER);
         addAndMakeVisible(*power[i]);
+        powerData[i]->onGuiSetValue = [w = juce::Component::SafePointer(this)]()
+        {
+            if (w)
+                w->optionalAllSoundsOffOnToggle();
+        };
 
         createComponent(editor, *this, mn[i].solo, solo[i], soloData[i], i);
         solo[i]->setLabel("S");
@@ -53,6 +58,7 @@ MixerPanel::MixerPanel(SixSinesEditor &e) : jcmp::NamedPanel("Mixer"), HasEditor
                                            true);
             w->editor.setAndSendParamValue(w->editor.patchCopy.sourceNodes[i].active.meta.id, true,
                                            true);
+            w->optionalAllSoundsOffOnToggle();
             w->repaint();
         };
 

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -156,7 +156,13 @@ SixSinesEditor::SixSinesEditor(Synth::audioToUIQueue_t &atou, Synth::mainToAudio
     vuMeter = std::make_unique<jcmp::VUMeter>(jcmp::VUMeter::HORIZONTAL);
     addAndMakeVisible(*vuMeter);
 
+    if (defaultsProvider->getUserDefaultValue(Defaults::designModeRunAllNodes, false))
+        sessionRunAllNodes = true;
+    if (defaultsProvider->getUserDefaultValue(Defaults::designModeAllSoundsOffOnToggle, false))
+        sessionAllSoundsOffOnToggle = true;
+
     mainToAudio.push({Synth::MainToAudioMsg::EDITOR_ATTACH_DETATCH, true});
+    sendDesignModeToAudio();
     mainToAudio.push({Synth::MainToAudioMsg::REQUEST_REFRESH, true});
     requestParamsFlush();
 
@@ -173,6 +179,8 @@ SixSinesEditor::SixSinesEditor(Synth::audioToUIQueue_t &atou, Synth::mainToAudio
 }
 SixSinesEditor::~SixSinesEditor()
 {
+    sessionRunAllNodes = false;
+    mainToAudio.push({Synth::MainToAudioMsg::SET_DESIGN_MODE_RUN_ALL, 0, 0.f});
     mainToAudio.push({Synth::MainToAudioMsg::EDITOR_ATTACH_DETATCH, false});
     idleTimer->stopTimer();
     setLookAndFeel(nullptr);
@@ -738,6 +746,51 @@ void SixSinesEditor::showPresetPopup()
 
     p.addSubMenu("User Interface", uim);
 
+    auto dm = juce::PopupMenu();
+    auto runAll = isRunAllNodes();
+    auto asoToggle = isAllSoundsOffOnToggle();
+    dm.addItem("Run all nodes independent of power", true, sessionRunAllNodes,
+               [w = juce::Component::SafePointer(this)]()
+               {
+                   if (!w)
+                       return;
+                   w->sessionRunAllNodes = !w->sessionRunAllNodes;
+                   w->sendDesignModeToAudio();
+               });
+    dm.addItem("All sounds off on power toggle", true, sessionAllSoundsOffOnToggle,
+               [w = juce::Component::SafePointer(this)]()
+               {
+                   if (!w)
+                       return;
+                   w->sessionAllSoundsOffOnToggle = !w->sessionAllSoundsOffOnToggle;
+               });
+    dm.addSeparator();
+    auto prefRunAll = defaultsProvider->getUserDefaultValue(Defaults::designModeRunAllNodes, false);
+    dm.addItem("Always run all nodes when UI is open", true, prefRunAll,
+               [w = juce::Component::SafePointer(this), prefRunAll]()
+               {
+                   if (!w)
+                       return;
+                   w->defaultsProvider->updateUserDefaultValue(Defaults::designModeRunAllNodes,
+                                                               !prefRunAll);
+                   if (!prefRunAll)
+                       w->sessionRunAllNodes = true;
+                   w->sendDesignModeToAudio();
+               });
+    auto prefASO =
+        defaultsProvider->getUserDefaultValue(Defaults::designModeAllSoundsOffOnToggle, false);
+    dm.addItem("Always send all sounds off on toggle when UI is open", true, prefASO,
+               [w = juce::Component::SafePointer(this), prefASO]()
+               {
+                   if (!w)
+                       return;
+                   w->defaultsProvider->updateUserDefaultValue(
+                       Defaults::designModeAllSoundsOffOnToggle, !prefASO);
+                   if (!prefASO)
+                       w->sessionAllSoundsOffOnToggle = true;
+               });
+    p.addSubMenu("Design Mode", dm);
+
     p.addSeparator();
     p.addItem("Read the Manual",
               []()
@@ -1243,6 +1296,16 @@ void SixSinesEditor::sneakyStartupGrabFrom(Patch &other)
     }
     strncpy(patchCopy.name, other.name, 255);
     postPatchChange(other.name);
+}
+
+bool SixSinesEditor::isRunAllNodes() const { return sessionRunAllNodes; }
+
+bool SixSinesEditor::isAllSoundsOffOnToggle() const { return sessionAllSoundsOffOnToggle; }
+
+void SixSinesEditor::sendDesignModeToAudio()
+{
+    mainToAudio.push(
+        {Synth::MainToAudioMsg::SET_DESIGN_MODE_RUN_ALL, 0, isRunAllNodes() ? 1.f : 0.f});
 }
 
 bool SixSinesEditor::toggleDebug()

--- a/src/ui/six-sines-editor.h
+++ b/src/ui/six-sines-editor.h
@@ -161,6 +161,12 @@ struct SixSinesEditor : jcmp::WindowPanel
 
     float engineSR{0}, hostSR{0};
 
+    bool sessionRunAllNodes{false};
+    bool sessionAllSoundsOffOnToggle{false};
+    bool isRunAllNodes() const;
+    bool isAllSoundsOffOnToggle() const;
+    void sendDesignModeToAudio();
+
     void requestParamsFlush();
     const clap_host_params_t *clapParamsExtension{nullptr};
 
@@ -172,6 +178,12 @@ struct HasEditor
 {
     SixSinesEditor &editor;
     HasEditor(SixSinesEditor &e) : editor(e) {}
+
+    void optionalAllSoundsOffOnToggle()
+    {
+        if (editor.isAllSoundsOffOnToggle())
+            editor.mainToAudio.push({Synth::MainToAudioMsg::PANIC_STOP_VOICES});
+    }
 };
 } // namespace baconpaul::six_sines::ui
 #endif

--- a/src/ui/source-panel.cpp
+++ b/src/ui/source-panel.cpp
@@ -37,6 +37,11 @@ SourcePanel::SourcePanel(SixSinesEditor &e) : jcmp::NamedPanel("Source"), HasEdi
         power[i]->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::GLYPH);
         power[i]->setGlyph(sst::jucegui::components::GlyphPainter::POWER);
         addAndMakeVisible(*power[i]);
+        powerData[i]->onGuiSetValue = [w = juce::Component::SafePointer(this)]()
+        {
+            if (w)
+                w->optionalAllSoundsOffOnToggle();
+        };
 
         labels[i] = std::make_unique<jcmp::Label>();
         labels[i]->setText("Op " + std::to_string(i + 1) + " Ratio");

--- a/src/ui/ui-defaults.h
+++ b/src/ui/ui-defaults.h
@@ -27,6 +27,8 @@ enum Defaults
     zoomLevel,
     useSoftwareRenderer, // only used on windows
     flipSourceAndMatrix,
+    designModeRunAllNodes,
+    designModeAllSoundsOffOnToggle,
     numDefaults
 };
 
@@ -42,6 +44,10 @@ inline std::string defaultName(Defaults d)
         return "useSoftwareRenderer";
     case flipSourceAndMatrix:
         return "flipSourceAndMatrix";
+    case designModeRunAllNodes:
+        return "designModeRunAllNodes";
+    case designModeAllSoundsOffOnToggle:
+        return "designModeAllSoundsOffOnToggle";
     case numDefaults:
     {
         SXSNLOG("Software Error - defaults found");


### PR DESCRIPTION
Adds two session-level (and optionally persistent) design mode features accessible from the preset menu under "Design Mode":

- "Run all nodes independent of power": sets a flag on MonoValues so voices initialize and run all operators/matrix/mixer nodes regardless of their active state, allowing power toggles to take effect on the next note without waiting for voices to die. Sends all-sounds-off when toggled so new voices start cleanly.

- "All sounds off on power toggle": sends all-sounds-off whenever a power button or drag-to-activate gesture fires in the UI, so the next note reflects the new routing immediately.

Both features default off. Persistent "always on when UI is open" preferences are also provided; enabling a preference also activates the session flag for the current session.