### PR TITLE
Modify to horizontal layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(${PROJECT_NAME}-impl STATIC
         src/ui/finetune-sub-panel.cpp
         src/ui/mainpan-sub-panel.cpp
         src/ui/playmode-sub-panel.cpp
+        src/ui/settings-panel.cpp
 
         src/presets/preset-manager.cpp
         src/presets/ui-theme-manager.cpp

--- a/src/ui/dahdsr-components.h
+++ b/src/ui/dahdsr-components.h
@@ -101,10 +101,7 @@ template <typename Comp, typename PatchPart> struct DAHDSRComponents
 
         namespace jlo = sst::jucegui::layouts;
 
-        auto lo = jlo::VList()
-                      .at(x, y)
-                      .withHeight(asComp()->getHeight() - y)
-                      .withWidth(nels * uicSliderWidth);
+        auto lo = jlo::VList().at(x, y).withHeight(180).withWidth(nels * uicSliderWidth);
 
         lo.add(titleLabelLayout(titleLab));
         auto sliders = jlo::HList().expandToFill();

--- a/src/ui/finetune-sub-panel.cpp
+++ b/src/ui/finetune-sub-panel.cpp
@@ -89,37 +89,32 @@ void FineTuneSubPanel::resized()
 {
     auto p = getLocalBounds().reduced(uicMargin, 0);
     auto pn = layoutDAHDSRAt(p.getX(), p.getY());
-    auto gh = (pn.getHeight() - 2 * uicPowerButtonSize) / 2;
     auto r = layoutLFOAt(pn.getX() + uicMargin, p.getY());
 
-    auto depx = r.getX() + uicMargin;
-    auto depy = r.getY();
+    auto depx = p.getX();
+    auto depy = std::min(pn.getBottom(), r.getBottom()) + uicMargin;
 
     namespace jlo = sst::jucegui::layouts;
-    auto lo = jlo::HList().at(depx, depy).withAutoGap(uicMargin * 2);
+    auto lo =
+        jlo::VList().at(depx, depy).withWidth(uicKnobSize * 2 + uicMargin).withAutoGap(uicMargin);
 
-    auto cel = jlo::VList().withWidth(uicSubPanelColumnWidth).withAutoGap(uicMargin);
-    cel.add(titleLabelGaplessLayout(tuneTitle));
-    cel.add(labelKnobLayout(fine, fineL).centerInParent());
-    cel.add(labelKnobLayout(coarse, coarseL).centerInParent());
-    lo.add(cel);
+    lo.add(titleLabelGaplessLayout(tuneTitle));
+    auto tk = jlo::HList().withHeight(uicLabeledKnobHeight).withAutoGap(uicMargin);
+    tk.add(labelKnobLayout(fine, fineL).centerInParent());
+    tk.add(labelKnobLayout(coarse, coarseL).centerInParent());
+    lo.add(tk);
 
-    auto kl = jlo::VList().withWidth(uicKnobSize * 2 + uicMargin * 2).withAutoGap(uicMargin);
-    kl.add(titleLabelGaplessLayout(envTitle));
+    lo.add(titleLabelGaplessLayout(envTitle));
+    auto ek = jlo::HList().withHeight(uicLabeledKnobHeight).withAutoGap(uicMargin);
+    ek.add(labelKnobLayout(envDepth, envDepthLL).centerInParent());
+    ek.add(labelKnobLayout(envCDepth, envCDepthLL).centerInParent());
+    lo.add(ek);
 
-    auto hl = jlo::HList().withAutoGap(uicMargin).withHeight(uicLabeledKnobHeight);
-    hl.add(labelKnobLayout(envDepth, envDepthLL));
-    hl.add(labelKnobLayout(envCDepth, envCDepthLL));
-    kl.add(hl);
-
-    kl.add(titleLabelGaplessLayout(lfoTitle));
-
-    hl = jlo::HList().withAutoGap(uicMargin).withHeight(uicLabeledKnobHeight);
-    hl.add(labelKnobLayout(lfoDep, lfoDepL));
-    hl.add(labelKnobLayout(lfoCDep, lfoCDepL));
-    kl.add(hl);
-
-    lo.add(kl);
+    lo.add(titleLabelGaplessLayout(lfoTitle));
+    auto lk = jlo::HList().withHeight(uicLabeledKnobHeight).withAutoGap(uicMargin);
+    lk.add(labelKnobLayout(lfoDep, lfoDepL).centerInParent());
+    lk.add(labelKnobLayout(lfoCDep, lfoCDepL).centerInParent());
+    lo.add(lk);
 
     lo.doLayout();
 

--- a/src/ui/macro-panel.cpp
+++ b/src/ui/macro-panel.cpp
@@ -23,7 +23,7 @@ namespace baconpaul::six_sines::ui
 MacroPanel::MacroPanel(SixSinesEditor &e) : jcmp::NamedPanel("Macros"), HasEditor(e)
 {
     auto &mn = editor.patchCopy.macroNodes;
-    for (auto i = 0U; i < numOps; ++i)
+    for (auto i = 0U; i < numMacros; ++i)
     {
         createComponent(editor, *this, mn[i].level, knobs[i], knobsData[i], i);
         knobs[i]->setDrawLabel(false);
@@ -34,6 +34,15 @@ MacroPanel::MacroPanel(SixSinesEditor &e) : jcmp::NamedPanel("Macros"), HasEdito
         labels[i] = std::make_unique<jcmp::Label>();
         labels[i]->setText("Macro " + std::to_string(i + 1));
         addAndMakeVisible(*labels[i]);
+
+        powerOnState[i] = true;
+        powerD[i] = std::make_unique<
+            sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::ToggleButton, bool>>(
+            powerOnState[i]);
+        power[i] = powerD[i]->widget.get();
+        power[i]->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::GLYPH);
+        power[i]->setGlyph(sst::jucegui::components::GlyphPainter::POWER);
+        addAndMakeVisible(*power[i]);
     }
 }
 MacroPanel::~MacroPanel() = default;
@@ -41,12 +50,12 @@ MacroPanel::~MacroPanel() = default;
 void MacroPanel::resized()
 {
     auto b = getContentArea().reduced(uicMargin, 0);
-    auto x = b.getX() + (b.getWidth() - uicKnobSize) / 2;
+    auto x = b.getX();
     auto y = b.getY();
-    for (auto i = 0U; i < numOps; ++i)
+    for (auto i = 0U; i < numMacros; ++i)
     {
-        positionKnobAndLabel(x, y, knobs[i], labels[i]);
-        y += uicLabeledKnobHeight + uicMargin;
+        positionPowerKnobAndLabel(x, y, power[i], knobs[i], labels[i], true);
+        x += uicPowerKnobWidth + uicMargin;
     }
 }
 

--- a/src/ui/macro-panel.h
+++ b/src/ui/macro-panel.h
@@ -19,6 +19,7 @@
 #include <sst/jucegui/components/Knob.h>
 #include <sst/jucegui/components/Label.h>
 #include <sst/jucegui/components/ToggleButton.h>
+#include <sst/jucegui/component-adapters/DiscreteToReference.h>
 #include <sst/jucegui/data/Continuous.h>
 #include "six-sines-editor.h"
 #include "patch-data-bindings.h"
@@ -37,9 +38,17 @@ struct MacroPanel : jcmp::NamedPanel, HasEditor
 
     void beginEdit(size_t idx);
 
-    std::array<std::unique_ptr<jcmp::Knob>, numOps> knobs;
-    std::array<std::unique_ptr<PatchContinuous>, numOps> knobsData;
-    std::array<std::unique_ptr<jcmp::Label>, numOps> labels;
+    std::array<std::unique_ptr<jcmp::Knob>, numMacros> knobs;
+    std::array<std::unique_ptr<PatchContinuous>, numMacros> knobsData;
+    std::array<std::unique_ptr<jcmp::Label>, numMacros> labels;
+
+    // Placeholder power toggles — not yet wired to any patch data.
+    std::array<bool, numMacros> powerOnState{};
+    std::array<std::unique_ptr<sst::jucegui::component_adapters::DiscreteToValueReference<
+                   jcmp::ToggleButton, bool>>,
+               numMacros>
+        powerD;
+    std::array<jcmp::ToggleButton *, numOps> power{};
 };
 } // namespace baconpaul::six_sines::ui
 #endif // Macro_PANE_H

--- a/src/ui/main-panel.cpp
+++ b/src/ui/main-panel.cpp
@@ -54,26 +54,6 @@ MainPanel::MainPanel(SixSinesEditor &e) : jcmp::NamedPanel("Main"), HasEditor(e)
         w->editor.fineTuneSubPanel->repaint();
     };
 
-    voiceCount = std::make_unique<jcmp::Label>();
-    addAndMakeVisible(*voiceCount);
-    setVoiceCount(0);
-
-    playScreenD = std::make_unique<
-        sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::ToggleButton, bool>>(
-        isPlayScreenShowing);
-    playScreen = playScreenD->widget.get();
-    playScreen->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::GLYPH_WITH_BG);
-    playScreen->setGlyph(sst::jucegui::components::GlyphPainter::SETTINGS);
-    addAndMakeVisible(*playScreen);
-    playScreenD->onValueChanged = [this](bool b)
-    {
-        if (b)
-        {
-            beginEdit(3);
-        }
-    };
-    sst::jucegui::component_adapters::setTraversalId(playScreen, 4);
-
     highlight = std::make_unique<KnobHighlight>(editor);
     addChildComponent(*highlight);
 }
@@ -89,14 +69,6 @@ void MainPanel::resized()
 
     b = b.withTrimmedLeft(uicKnobSize + uicMargin);
     positionKnobAndLabel(b.getX(), b.getY(), tun, tunLabel);
-    b = b.withTrimmedLeft(uicKnobSize + uicMargin);
-
-    positionKnobAndLabel(b.getX(), b.getY(), playScreenD->widget, voiceCount);
-
-    // vb = vb.translated(0, uicLabelHeight + uicMargin);
-    // voiceCount->setBounds(vb);
-    // vb = vb.translated(0, uicLabelHeight + uicMargin);
-    // voiceLimit->setBounds(vb);
 }
 
 void MainPanel::mouseDown(const juce::MouseEvent &e)
@@ -124,15 +96,8 @@ juce::Rectangle<int> MainPanel::rectangleFor(int idx)
 
 void MainPanel::beginEdit(int which)
 {
-    if (which == 3)
-        supressPowerOff = true;
     editor.hideAllSubPanels();
-    editor.activateHamburger(which != 3);
-    supressPowerOff = false;
-    if (which != 3)
-    {
-        playScreenD->setValueFromModel(false);
-    }
+    editor.activateHamburger(true);
     if (which == 0)
     {
         editor.mainSubPanel->setVisible(true);
@@ -154,14 +119,6 @@ void MainPanel::beginEdit(int which)
         editor.singlePanel->setName("Main Tuning");
         auto b = getContentArea().reduced(uicMargin, 0);
         highlight->setBounds(b.getX() + 2 * uicKnobSize + 1.5 * uicMargin, b.getY(),
-                             uicKnobSize + uicMargin, uicLabeledKnobHeight);
-    }
-    else if (which == 3)
-    {
-        editor.playModeSubPanel->setVisible(true);
-        editor.singlePanel->setName("Settings");
-        auto b = getContentArea().reduced(uicMargin, 0);
-        highlight->setBounds(b.getX() + 3 * uicKnobSize + 2.5 * uicMargin, b.getY(),
                              uicKnobSize + uicMargin, uicLabeledKnobHeight);
     }
     highlight->setVisible(true);

--- a/src/ui/main-panel.h
+++ b/src/ui/main-panel.h
@@ -16,10 +16,7 @@
 #ifndef BACONPAUL_SIX_SINES_UI_MAIN_PANEL_H
 #define BACONPAUL_SIX_SINES_UI_MAIN_PANEL_H
 
-#include <sst/jucegui/component-adapters/DiscreteToReference.h>
-
 #include "sst/jucegui/components/Label.h"
-#include "sst/jucegui/components/VUMeter.h"
 
 #include "six-sines-editor.h"
 #include "patch-data-bindings.h"
@@ -39,13 +36,10 @@ struct MainPanel : jcmp::NamedPanel, HasEditor
     void beginEdit(int which);
 
     std::unique_ptr<juce::Component> highlight;
-    bool supressPowerOff{false};
     void clearHighlight()
     {
         if (highlight)
             highlight->setVisible(false);
-        if (playScreenD && !supressPowerOff)
-            playScreenD->setValueFromModel(false);
     }
 
     std::unique_ptr<PatchContinuous> levData;
@@ -59,15 +53,6 @@ struct MainPanel : jcmp::NamedPanel, HasEditor
     std::unique_ptr<PatchContinuous> tunData;
     std::unique_ptr<jcmp::Knob> tun;
     std::unique_ptr<jcmp::Label> tunLabel;
-
-    void setVoiceCount(int vc) { voiceCount->setText("V: " + std::to_string(vc)); }
-    std::unique_ptr<jcmp::Label> voiceCount;
-
-    jcmp::ToggleButton *playScreen{nullptr}; // owned by the d. detail to fix up later
-    std::unique_ptr<
-        sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::ToggleButton, bool>>
-        playScreenD;
-    bool isPlayScreenShowing{false};
 };
 } // namespace baconpaul::six_sines::ui
 #endif // MAIN_PANEL_H

--- a/src/ui/main-sub-panel.cpp
+++ b/src/ui/main-sub-panel.cpp
@@ -56,18 +56,20 @@ void MainSubPanel::resized()
 {
     auto p = getLocalBounds().reduced(uicMargin, 0);
     auto r = layoutDAHDSRAt(p.getX(), p.getY());
-    r = layoutLFOAt(r.getX() + uicMargin, p.getY());
+    auto r2 = layoutLFOAt(r.getX() + uicMargin, p.getY());
 
-    auto depx = r.getX() + uicMargin;
-    auto depy = r.getY();
+    auto depx = p.getX();
+    auto depy = std::min(r.getBottom(), r2.getBottom()) + uicMargin;
 
     namespace jlo = sst::jucegui::layouts;
     auto lo = jlo::HList().at(depx, depy).withAutoGap(uicMargin * 2);
 
-    auto el = jlo::VList().withWidth(uicSubPanelColumnWidth).withAutoGap(uicMargin);
+    auto el = jlo::VList().withWidth(uicKnobSize * 2 + uicMargin).withAutoGap(uicMargin);
     el.add(titleLabelGaplessLayout(velTitle));
-    el.add(labelKnobLayout(velSen, velSenL).centerInParent());
-    el.add(labelKnobLayout(lfoDep, lfoDepL).centerInParent());
+    auto kl = jlo::HList().withHeight(uicLabeledKnobHeight).withAutoGap(uicMargin);
+    kl.add(labelKnobLayout(velSen, velSenL).centerInParent());
+    kl.add(labelKnobLayout(lfoDep, lfoDepL).centerInParent());
+    el.add(kl);
     lo.add(el);
 
     lo.doLayout();

--- a/src/ui/mainpan-sub-panel.cpp
+++ b/src/ui/mainpan-sub-panel.cpp
@@ -54,19 +54,20 @@ void MainPanSubPanel::resized()
 {
     auto p = getLocalBounds().reduced(uicMargin, 0);
     auto pn = layoutDAHDSRAt(p.getX(), p.getY());
-    auto gh = (pn.getHeight() - 2 * uicPowerButtonSize) / 2;
     auto r = layoutLFOAt(pn.getX() + uicMargin, p.getY());
 
-    auto depx = r.getX() + uicMargin;
-    auto depy = r.getY();
+    auto depx = p.getX();
+    auto depy = std::min(pn.getBottom(), r.getBottom()) + uicMargin;
 
     namespace jlo = sst::jucegui::layouts;
     auto lo = jlo::HList().at(depx, depy).withAutoGap(uicMargin * 2);
 
-    auto el = jlo::VList().withWidth(uicSubPanelColumnWidth).withAutoGap(uicMargin);
+    auto el = jlo::VList().withWidth(uicKnobSize * 2 + uicMargin).withAutoGap(uicMargin);
     el.add(titleLabelGaplessLayout(depTitle));
-    el.add(labelKnobLayout(envDepth, envDepthLL).centerInParent());
-    el.add(labelKnobLayout(lfoDep, lfoDepL).centerInParent());
+    auto kl = jlo::HList().withHeight(uicLabeledKnobHeight).withAutoGap(uicMargin);
+    kl.add(labelKnobLayout(envDepth, envDepthLL).centerInParent());
+    kl.add(labelKnobLayout(lfoDep, lfoDepL).centerInParent());
+    el.add(kl);
     lo.add(el);
 
     lo.doLayout();

--- a/src/ui/matrix-sub-panel.cpp
+++ b/src/ui/matrix-sub-panel.cpp
@@ -91,8 +91,8 @@ void MatrixSubPanel::resized()
     pn = pn.translated(uicMargin, 0);
     auto r = layoutLFOAt(pn.getX(), p.getY());
 
-    auto depx = r.getX() + uicMargin;
-    auto depy = r.getY();
+    auto depx = p.getX();
+    auto depy = std::min(pn.getBottom(), r.getBottom()) + uicMargin;
 
     namespace jlo = sst::jucegui::layouts;
     auto lo = jlo::HList().at(depx, depy).withAutoGap(uicMargin * 2);

--- a/src/ui/mixer-panel.cpp
+++ b/src/ui/mixer-panel.cpp
@@ -68,6 +68,9 @@ MixerPanel::MixerPanel(SixSinesEditor &e) : jcmp::NamedPanel("Mixer"), HasEditor
         panLabels[i]->setText("Pan");
         addAndMakeVisible(*panLabels[i]);
 
+        vuMeters[i] = std::make_unique<jcmp::VUMeter>(jcmp::VUMeter::VERTICAL);
+        addAndMakeVisible(*vuMeters[i]);
+
         sst::jucegui::component_adapters::setTraversalId(power[i].get(), i * 12 + 50);
         sst::jucegui::component_adapters::setTraversalId(solo[i].get(), i * 12 + 51);
         sst::jucegui::component_adapters::setTraversalId(knobs[i].get(), i * 12 + 52);
@@ -89,6 +92,8 @@ void MixerPanel::resized()
         positionPowerKnobSwitchAndLabel(x, y, power[i], solo[i], knobs[i], labels[i]);
         solo[i]->setBounds(solo[i]->getBounds().reduced(4, 0).translated(0, -1));
         positionKnobAndLabel(x + uicPowerKnobWidth + uicMargin, y, panKnobs[i], panLabels[i]);
+        auto vuX = x + uicPowerKnobWidth + uicMargin + uicKnobSize + 2 * uicMargin;
+        vuMeters[i]->setBounds(vuX, y, 13, uicKnobSize);
         y += uicLabeledKnobHeight + uicMargin;
     }
 }

--- a/src/ui/mixer-panel.h
+++ b/src/ui/mixer-panel.h
@@ -19,6 +19,7 @@
 #include <sst/jucegui/components/Knob.h>
 #include <sst/jucegui/components/Label.h>
 #include <sst/jucegui/components/ToggleButton.h>
+#include <sst/jucegui/components/VUMeter.h>
 #include <sst/jucegui/data/Continuous.h>
 #include "six-sines-editor.h"
 #include "patch-data-bindings.h"
@@ -58,6 +59,9 @@ struct MixerPanel : jcmp::NamedPanel, HasEditor
     std::array<std::unique_ptr<jcmp::Knob>, numOps> panKnobs;
     std::array<std::unique_ptr<PatchContinuous>, numOps> panKnobsData;
     std::array<std::unique_ptr<jcmp::Label>, numOps> panLabels;
+
+    // Small per-op vertical VU meters — not yet hooked up to a signal source.
+    std::array<std::unique_ptr<jcmp::VUMeter>, numOps> vuMeters;
 };
 } // namespace baconpaul::six_sines::ui
 #endif // MIXER_PANE_H

--- a/src/ui/mixer-sub-panel.cpp
+++ b/src/ui/mixer-sub-panel.cpp
@@ -87,11 +87,10 @@ void MixerSubPanel::resized()
 {
     auto p = getLocalBounds().reduced(uicMargin, 0);
     auto pn = layoutDAHDSRAt(p.getX(), p.getY());
-    auto gh = (pn.getHeight() - 2 * uicPowerButtonSize) / 2;
     auto r = layoutLFOAt(pn.getX() + uicMargin, p.getY());
 
-    auto depx = r.getX() + uicMargin;
-    auto depy = r.getY();
+    auto depx = p.getX();
+    auto depy = std::min(pn.getBottom(), r.getBottom()) + uicMargin;
 
     namespace jlo = sst::jucegui::layouts;
     auto lo = jlo::HList().at(depx, depy).withAutoGap(uicMargin * 2);

--- a/src/ui/modulation-components.h
+++ b/src/ui/modulation-components.h
@@ -39,7 +39,7 @@ template <typename Comp, typename Patch> struct ModulationComponents
         patchPtr = &v;
         auto c = asComp();
         modTitleLab = std::make_unique<jcmp::RuledLabel>();
-        modTitleLab->setText("Modulation");
+        modTitleLab->setText("Other Modulation");
         asComp()->addAndMakeVisible(*modTitleLab);
 
         for (int i = 0; i < numModsPer; ++i)
@@ -135,33 +135,29 @@ template <typename Comp, typename Patch> struct ModulationComponents
 
     void layoutModulation(const juce::Rectangle<int> &r)
     {
-        auto modW{uicModulationWidth};
-
         namespace jlo = sst::jucegui::layouts;
 
+        auto rowHeight = static_cast<int>(uicLabelHeight) + 4;
+        auto nMods = static_cast<int>(numModsPer);
+        auto totalHeight = static_cast<int>(uicTitleLabelHeight) + nMods * rowHeight +
+                           (nMods - 1) * static_cast<int>(uicMargin);
+
         auto lo = jlo::VList()
-                      .at(r.getRight() - uicModulationWidth, r.getY())
-                      .withHeight(asComp()->getHeight() - r.getY())
-                      .withWidth(uicModulationWidth);
+                      .at(r.getX(), r.getBottom() - totalHeight)
+                      .withWidth(r.getWidth())
+                      .withHeight(totalHeight);
 
         lo.add(titleLabelLayout(modTitleLab));
 
         for (int i = 0; i < numModsPer; ++i)
         {
-            auto hl = jlo::HList()
-                          .withWidth(uicModulationWidth)
-                          .withHeight(uicKnobSize)
-                          .withAutoGap(uicMargin);
-
-            auto vl = jlo::VList().expandToFill().withAutoGap(uicLabelGap);
-            vl.add(jlo::Component(*sourceMenu[i]).expandToFill());
-            vl.add(jlo::Component(*targetMenu[i]).expandToFill());
-
-            hl.add(vl);
-            hl.add(jlo::Component(*depthSlider[i]).withWidth(uicKnobSize));
-
+            auto hl = jlo::HList().withHeight(rowHeight).withAutoGap(uicMargin);
+            hl.add(jlo::Component(*sourceMenu[i]).expandToFill());
+            hl.add(jlo::Component(*targetMenu[i]).expandToFill());
+            hl.add(jlo::Component(*depthSlider[i]).expandToFill().insetBy(0, uicMargin));
             lo.add(hl);
-            lo.addGap(uicMargin * 2);
+            if (i < numModsPer - 1)
+                lo.addGap(uicMargin);
         }
 
         lo.doLayout();
@@ -262,7 +258,7 @@ template <typename Comp, typename Patch> struct ModulationComponents
 
     std::array<std::unique_ptr<jcmp::MenuButton>, numModsPer> sourceMenu;
     std::array<std::unique_ptr<jcmp::MenuButton>, numModsPer> targetMenu;
-    std::array<std::unique_ptr<jcmp::Knob>, numModsPer> depthSlider;
+    std::array<std::unique_ptr<jcmp::HSliderFilled>, numModsPer> depthSlider;
     std::array<std::unique_ptr<PatchContinuous>, numModsPer> depthSliderD;
 };
 } // namespace baconpaul::six_sines::ui

--- a/src/ui/playmode-sub-panel.cpp
+++ b/src/ui/playmode-sub-panel.cpp
@@ -198,25 +198,34 @@ PlayModeSubPanel::PlayModeSubPanel(SixSinesEditor &e) : HasEditor(e)
 void PlayModeSubPanel::resized()
 {
     namespace jlo = sst::jucegui::layouts;
-    auto lo = jlo::HList().at(uicMargin, 0).withAutoGap(2 * uicMargin);
-
-    // Voice Bend and Octave
     auto skinny = uicKnobSize + 30;
-    auto vbol = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
+    auto playRowHeight =
+        uicTitleLabelInnerBox + 2 * uicLabelHeight + uicMargin + 5 * uicLabelHeight + 6 * uicMargin;
 
-    vbol.add(titleLabelGaplessLayout(voiceLimitL));
-    vbol.add(jlo::Component(*voiceLimit).withHeight(uicLabelHeight));
-    vbol.add(titleLabelGaplessLayout(bendTitle));
+    auto outer = jlo::HList().at(uicMargin, 0).withAutoGap(2 * uicMargin);
 
-    vbol.add(sideLabel(bUpL, bUp));
-    vbol.add(sideLabel(bDnL, bDn));
+    // Column 1: voices / bend / octave / mpe / panic
+    auto col1 = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
+    col1.add(titleLabelGaplessLayout(voiceLimitL));
+    col1.add(jlo::Component(*voiceLimit).withHeight(uicLabelHeight));
+    col1.add(titleLabelGaplessLayout(bendTitle));
+    col1.add(sideLabel(bUpL, bUp));
+    col1.add(sideLabel(bDnL, bDn));
+    col1.add(titleLabelGaplessLayout(tsposeTitle));
+    col1.add(jlo::Component(*tsposeButton).withHeight(uicLabelHeight));
+    col1.add(titleLabelGaplessLayout(mpeTitle));
+    col1.add(jlo::Component(*mpeActiveButton).withHeight(uicLabelHeight));
+    col1.add(jlo::Component(*mpeRange).withHeight(uicLabelHeight));
+    col1.add(jlo::Component(*mpeRangeL).withHeight(uicLabelHeight));
+    col1.add(titleLabelGaplessLayout(panicTitle));
+    col1.add(jlo::Component(*panicButton).withHeight(uicLabelHeight));
+    outer.add(col1);
 
-    vbol.add(titleLabelGaplessLayout(tsposeTitle));
-    vbol.add(jlo::Component(*tsposeButton).withHeight(uicLabelHeight));
+    // Column 2: play + unison on top, oversampling below
+    auto col2 = jlo::VList().withWidth(2 * skinny + 2 * uicMargin).withAutoGap(2 * uicMargin);
 
-    lo.add(vbol);
+    auto topRow = jlo::HList().withHeight(playRowHeight).withAutoGap(2 * uicMargin);
 
-    // Play mode
     auto pml = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
     pml.add(titleLabelGaplessLayout(playTitle));
     pml.add(jlo::Component(*playMode).withHeight(2 * uicLabelHeight + uicMargin));
@@ -225,9 +234,8 @@ void PlayModeSubPanel::resized()
     pml.add(jlo::Component(*portaL).withHeight(uicLabelHeight));
     pml.add(jlo::Component(*portaTime).withHeight(uicLabelHeight).insetBy(0, 2));
     pml.add(jlo::Component(*portaContinuationButton).withHeight(uicLabelHeight));
-    lo.add(pml);
+    topRow.add(pml);
 
-    // Unison Controls
     auto uml = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
     uml.add(titleLabelGaplessLayout(uniTitle));
     uml.add(jlo::Component(*uniCt).withHeight(uicLabelHeight));
@@ -235,26 +243,19 @@ void PlayModeSubPanel::resized()
     uml.add(jlo::Component(*uniRPhase).withHeight(uicLabelHeight));
     uml.add(sideLabelSlider(uniSpreadG, uniSpread));
     uml.add(sideLabelSlider(uniPanG, uniPan));
+    topRow.add(uml);
 
-    lo.add(uml);
+    col2.add(topRow);
 
-    auto mpl = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
-    mpl.add(titleLabelGaplessLayout(mpeTitle));
-    mpl.add(jlo::Component(*mpeActiveButton).withHeight(uicLabelHeight));
-    mpl.add(jlo::Component(*mpeRange).withHeight(uicLabelHeight));
-    mpl.add(jlo::Component(*mpeRangeL).withHeight(uicLabelHeight));
-
-    mpl.add(titleLabelGaplessLayout(panicTitle));
-    mpl.add(jlo::Component(*panicButton).withHeight(uicLabelHeight));
-    lo.add(mpl);
-
-    auto rsl = jlo::VList().withWidth(2 * skinny).withAutoGap(uicMargin);
+    auto rsl = jlo::VList().withAutoGap(uicMargin);
     rsl.add(titleLabelGaplessLayout(srStratLab));
     rsl.add(jlo::Component(*srStrat).withHeight(uicLabelHeight));
     rsl.add(jlo::Component(*rsEng).withHeight(uicLabelHeight));
-    lo.add(rsl);
+    col2.add(rsl);
 
-    lo.doLayout();
+    outer.add(col2);
+
+    outer.doLayout();
 }
 
 void PlayModeSubPanel::setTriggerButtonLabel()

--- a/src/ui/self-sub-panel.cpp
+++ b/src/ui/self-sub-panel.cpp
@@ -88,12 +88,11 @@ void SelfSubPanel::resized()
 {
     auto p = getLocalBounds().reduced(uicMargin, 0);
     auto pn = layoutDAHDSRAt(p.getX(), p.getY());
-    auto gh = (pn.getHeight() - 2 * uicPowerButtonSize) / 2;
     pn = pn.translated(uicMargin, 0);
     auto r = layoutLFOAt(pn.getX(), p.getY());
 
-    auto depx = r.getX() + uicMargin;
-    auto depy = r.getY();
+    auto depx = p.getX();
+    auto depy = std::min(pn.getBottom(), r.getBottom()) + uicMargin;
 
     namespace jlo = sst::jucegui::layouts;
     auto lo = jlo::HList().at(depx, depy).withAutoGap(uicMargin * 2);

--- a/src/ui/settings-panel.cpp
+++ b/src/ui/settings-panel.cpp
@@ -1,0 +1,83 @@
+/*
+ * Six Sines
+ *
+ * A synth with audio rate modulation.
+ *
+ * Copyright 2024-2025, Paul Walker and Various authors, as described in the github
+ * transaction log.
+ *
+ * This source repo is released under the MIT license, but has
+ * GPL3 dependencies, as such the combined work will be
+ * released under GPL3.
+ *
+ * The source code and license are at https://github.com/baconpaul/six-sines
+ */
+
+#include "settings-panel.h"
+#include "ui-constants.h"
+#include "playmode-sub-panel.h"
+
+namespace baconpaul::six_sines::ui
+{
+SettingsPanel::SettingsPanel(SixSinesEditor &e) : jcmp::NamedPanel("Settings"), HasEditor(e)
+{
+    hasHamburger = false;
+
+    playScreenD = std::make_unique<
+        sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::ToggleButton, bool>>(
+        isPlayScreenShowing);
+    playScreen = playScreenD->widget.get();
+    playScreen->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::GLYPH_WITH_BG);
+    playScreen->setGlyph(sst::jucegui::components::GlyphPainter::SETTINGS);
+    addAndMakeVisible(*playScreen);
+    playScreenD->onValueChanged = [this](bool b)
+    {
+        if (b)
+            beginEdit();
+    };
+    sst::jucegui::component_adapters::setTraversalId(playScreen, 4);
+
+    voiceCount = std::make_unique<jcmp::Label>();
+    setVoiceCount(0);
+    addAndMakeVisible(*voiceCount);
+
+    cpuLabel = std::make_unique<jcmp::Label>();
+    cpuLabel->setText("CPU: 0.0%");
+    addAndMakeVisible(*cpuLabel);
+}
+
+SettingsPanel::~SettingsPanel() = default;
+
+void SettingsPanel::resized()
+{
+    auto sb = getContentArea().reduced(uicMargin, 0);
+    int settingsBtnSize = uicKnobSize + 8;
+    int btnX = sb.getX() + 2 * uicMargin;
+    int btnY = sb.getY() + (sb.getHeight() - settingsBtnSize) / 2;
+    playScreen->setBounds(btnX, btnY, settingsBtnSize, settingsBtnSize);
+
+    int labelX = btnX + settingsBtnSize + 2 * uicMargin;
+    int labelW = sb.getRight() - labelX;
+    int labelH = uicLabelHeight;
+    int labelsY = sb.getY() + (sb.getHeight() - 2 * labelH) / 2;
+    voiceCount->setBounds(labelX, labelsY, labelW, labelH);
+    cpuLabel->setBounds(labelX, labelsY + labelH, labelW, labelH);
+}
+
+void SettingsPanel::beginEdit()
+{
+    suppressPowerOff = true;
+    editor.hideAllSubPanels();
+    editor.activateHamburger(false);
+    suppressPowerOff = false;
+
+    editor.playModeSubPanel->setVisible(true);
+    editor.singlePanel->setName("Settings");
+}
+
+void SettingsPanel::clearHighlight()
+{
+    if (playScreenD && !suppressPowerOff)
+        playScreenD->setValueFromModel(false);
+}
+} // namespace baconpaul::six_sines::ui

--- a/src/ui/settings-panel.h
+++ b/src/ui/settings-panel.h
@@ -1,0 +1,49 @@
+/*
+ * Six Sines
+ *
+ * A synth with audio rate modulation.
+ *
+ * Copyright 2024-2025, Paul Walker and Various authors, as described in the github
+ * transaction log.
+ *
+ * This source repo is released under the MIT license, but has
+ * GPL3 dependencies, as such the combined work will be
+ * released under GPL3.
+ *
+ * The source code and license are at https://github.com/baconpaul/six-sines
+ */
+
+#ifndef BACONPAUL_SIX_SINES_UI_SETTINGS_PANEL_H
+#define BACONPAUL_SIX_SINES_UI_SETTINGS_PANEL_H
+
+#include <sst/jucegui/components/Label.h>
+#include <sst/jucegui/components/NamedPanel.h>
+#include <sst/jucegui/components/ToggleButton.h>
+#include <sst/jucegui/component-adapters/DiscreteToReference.h>
+#include "six-sines-editor.h"
+
+namespace baconpaul::six_sines::ui
+{
+struct SettingsPanel : jcmp::NamedPanel, HasEditor
+{
+    SettingsPanel(SixSinesEditor &);
+    ~SettingsPanel();
+
+    void resized() override;
+    void beginEdit();
+    void clearHighlight();
+
+    void setVoiceCount(int vc) { voiceCount->setText("Voices: " + std::to_string(vc)); }
+
+    std::unique_ptr<jcmp::Label> voiceCount;
+    std::unique_ptr<jcmp::Label> cpuLabel;
+
+    bool isPlayScreenShowing{false};
+    bool suppressPowerOff{false};
+    jcmp::ToggleButton *playScreen{nullptr};
+    std::unique_ptr<
+        sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::ToggleButton, bool>>
+        playScreenD;
+};
+} // namespace baconpaul::six_sines::ui
+#endif // SETTINGS_PANEL_H

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -28,6 +28,7 @@
 #include "matrix-sub-panel.h"
 #include "finetune-sub-panel.h"
 #include "playmode-sub-panel.h"
+#include "settings-panel.h"
 #include "mainpan-sub-panel.h"
 #include "self-sub-panel.h"
 #include "mixer-panel.h"
@@ -103,6 +104,8 @@ SixSinesEditor::SixSinesEditor(Synth::audioToUIQueue_t &atou, Synth::mainToAudio
     addAndMakeVisible(*sourcePanel);
     addAndMakeVisible(*mainPanel);
     addAndMakeVisible(*macroPanel);
+    settingsPanel = std::make_unique<SettingsPanel>(*this);
+    addAndMakeVisible(*settingsPanel);
 
     mainSubPanel = std::make_unique<MainSubPanel>(*this);
     singlePanel->addChildComponent(*mainSubPanel);
@@ -189,7 +192,14 @@ SixSinesEditor::SixSinesEditor(Synth::audioToUIQueue_t &atou, Synth::mainToAudio
     mainToAudio.push({Synth::MainToAudioMsg::REQUEST_REFRESH, true});
     requestParamsFlush();
 
-    auto pzf = defaultsProvider->getUserDefaultValue(Defaults::zoomLevel, 100);
+    auto defaultZoomPct = 100;
+    if (auto *d = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay())
+    {
+        auto sz = d->totalArea;
+        if (sz.getWidth() <= 1366 && sz.getHeight() <= 768)
+            defaultZoomPct = 90;
+    }
+    auto pzf = defaultsProvider->getUserDefaultValue(Defaults::zoomLevel, defaultZoomPct);
     zoomFactor = pzf * 0.01;
     setTransform(juce::AffineTransform().scaled(zoomFactor));
 
@@ -229,8 +239,8 @@ void SixSinesEditor::idle()
         }
         else if (aum->action == Synth::AudioToUIMsg::UPDATE_VOICE_COUNT)
         {
-            mainPanel->setVoiceCount(aum->paramId);
-            mainPanel->repaint();
+            settingsPanel->setVoiceCount(aum->paramId);
+            settingsPanel->repaint();
         }
         else if (aum->action == Synth::AudioToUIMsg::SET_PATCH_NAME)
         {
@@ -356,42 +366,57 @@ void SixSinesEditor::resized()
 
     auto lb = getLocalBounds();
     auto presetArea = lb.withHeight(presetHeight);
-    auto panelArea = lb.withTrimmedTop(presetHeight).withTrimmedBottom(footerHeight);
 
     auto panelPadX{2 * uicMargin + 11}, panelPadY{34U};
     auto sourceHeight = uicLabeledKnobHeight + panelPadY;
+    auto macroStripHeight = sourceHeight;
+
+    auto panelArea =
+        lb.withTrimmedTop(presetHeight).withTrimmedBottom(footerHeight + macroStripHeight);
 
     auto matrixWidth = numOps * (uicPowerKnobWidth) + (numOps - 1) * uicMargin + panelPadX;
     auto matrixHeight = numOps * uicLabeledKnobHeight + (numOps - 1) * uicMargin + panelPadY;
-    auto mixerWidth = uicKnobSize + uicPowerKnobWidth + uicMargin + panelPadX;
-    auto macroWidth = uicKnobSize + panelPadX + 6;
-    auto mainWidth = mixerWidth + macroWidth;
-
-    auto editHeight = 220;
+    // Right column (main above mixer). Sized to fit the mixer row:
+    //   power+level (uicPowerKnobWidth) + gap + pan knob + gap + small vertical VU.
+    // This is wider than the 3-knob main panel so main just has some slack.
+    auto mixerVuWidth = 22U;
+    auto rightColWidth =
+        uicPowerKnobWidth + uicMargin + uicKnobSize + uicMargin + mixerVuWidth + panelPadX;
 
     auto panelMargin{1};
 
-    // Preset button
-    auto but = presetArea.reduced(110, 0).withTrimmedTop(uicMargin);
-    presetButton->setBounds(but);
-    but = but.withLeft(presetButton->getRight() + uicMargin).withRight(getWidth() - uicMargin);
+    // Top bar: [ preset | vu ]
+    auto topInner = presetArea.withTrimmedTop(uicMargin);
+    int vuWidth = 150;
 
-    vuMeter->setBounds(but);
+    auto vuRect = juce::Rectangle<int>(getWidth() - uicMargin - vuWidth, topInner.getY(), vuWidth,
+                                       topInner.getHeight());
+    vuMeter->setBounds(vuRect);
+
+    int presetLeft = 110;
+    auto presetRect = juce::Rectangle<int>(
+        presetLeft, topInner.getY(), vuRect.getX() - uicMargin - presetLeft, topInner.getHeight());
+    presetButton->setBounds(presetRect);
 
     auto sourceRect =
         juce::Rectangle<int>(panelArea.getX(), panelArea.getY(), matrixWidth, sourceHeight);
     auto matrixRect = juce::Rectangle<int>(panelArea.getX(), panelArea.getY() + sourceHeight,
                                            matrixWidth, matrixHeight);
     auto mainRect = juce::Rectangle<int>(panelArea.getX() + matrixWidth, panelArea.getY(),
-                                         mainWidth, sourceHeight);
-    auto mixerRect = juce::Rectangle<int>(
-        panelArea.getX() + matrixWidth, panelArea.getY() + sourceHeight, mixerWidth, matrixHeight);
+                                         rightColWidth, sourceHeight);
+    auto mixerRect =
+        juce::Rectangle<int>(panelArea.getX() + matrixWidth, panelArea.getY() + sourceHeight,
+                             rightColWidth, matrixHeight);
+    auto editX = panelArea.getX() + matrixWidth + rightColWidth;
+    auto editRect = juce::Rectangle<int>(editX, panelArea.getY(), panelArea.getRight() - editX,
+                                         sourceHeight + matrixHeight + macroStripHeight);
+
+    // Macro strip sits under the matrix, sized to match it. The Settings sub-panel
+    // takes the remaining width (under the mixer column). Edit panel is to the right.
     auto macroRect =
-        juce::Rectangle<int>(panelArea.getX() + matrixWidth + mixerWidth,
-                             panelArea.getY() + sourceHeight, macroWidth, matrixHeight);
-    auto editRect =
-        juce::Rectangle<int>(panelArea.getX(), panelArea.getY() + sourceHeight + matrixHeight,
-                             matrixWidth + mainWidth, editHeight);
+        juce::Rectangle<int>(lb.getX(), panelArea.getBottom(), matrixWidth, macroStripHeight);
+    auto settingsPanelRect = juce::Rectangle<int>(lb.getX() + matrixWidth, panelArea.getBottom(),
+                                                  rightColWidth, macroStripHeight);
 
     bool flipSourceAndMatrix =
         defaultsProvider->getUserDefaultValue(Defaults::flipSourceAndMatrix, false);
@@ -400,7 +425,6 @@ void SixSinesEditor::resized()
         auto sy = sourceRect.getY();
         auto mb = matrixRect.getBottom() - sourceRect.getHeight();
         matrixRect.setY(sy);
-        macroRect.setY(sy);
         mixerRect.setY(sy);
         sourceRect.setY(mb);
         mainRect.setY(mb);
@@ -411,6 +435,7 @@ void SixSinesEditor::resized()
     mainPanel->setBounds(mainRect.reduced(panelMargin));
     mixerPanel->setBounds(mixerRect.reduced(panelMargin));
     macroPanel->setBounds(macroRect.reduced(panelMargin));
+    settingsPanel->setBounds(settingsPanelRect.reduced(panelMargin));
     singlePanel->setBounds(editRect.reduced(panelMargin));
 
     mainSubPanel->setBounds(singlePanel->getContentArea());
@@ -433,6 +458,7 @@ void SixSinesEditor::hideAllSubPanels()
     sourcePanel->clearHighlight();
     matrixPanel->clearHighlight();
     mixerPanel->clearHighlight();
+    settingsPanel->clearHighlight();
 }
 
 void SixSinesEditor::showTooltipOn(juce::Component *c)

--- a/src/ui/six-sines-editor.h
+++ b/src/ui/six-sines-editor.h
@@ -57,6 +57,7 @@ struct PlayModeSubPanel;
 struct SourcePanel;
 struct SourceSubPanel;
 struct MacroPanel;
+struct SettingsPanel;
 struct Clipboard;
 struct PresetDataBinding;
 
@@ -102,6 +103,7 @@ struct SixSinesEditor : jcmp::WindowPanel
     std::unique_ptr<MixerSubPanel> mixerSubPanel;
 
     std::unique_ptr<MacroPanel> macroPanel;
+    std::unique_ptr<SettingsPanel> settingsPanel;
 
     std::unique_ptr<SourcePanel> sourcePanel;
     std::unique_ptr<SourceSubPanel> sourceSubPanel;
@@ -190,7 +192,7 @@ struct SixSinesEditor : jcmp::WindowPanel
     std::function<void(float)> onZoomChanged{nullptr};
     bool toggleDebug();
 
-    static constexpr uint32_t edWidth{688}, edHeight{812};
+    static constexpr uint32_t edWidth{1048}, edHeight{690};
 
     std::unique_ptr<jcmp::VUMeter> vuMeter;
 

--- a/src/ui/source-sub-panel.cpp
+++ b/src/ui/source-sub-panel.cpp
@@ -223,32 +223,46 @@ void SourceSubPanel::resized()
 {
     auto p = getLocalBounds().reduced(uicMargin, 0);
     auto pn = layoutDAHDSRAt(p.getX(), p.getY());
-    auto gh = (pn.getHeight() - 2 * uicPowerButtonSize) / 2;
     pn = pn.translated(uicMargin, 0);
     auto r = layoutLFOAt(pn.getX(), p.getY());
 
+    auto depx = p.getX();
+    auto depy = std::min(pn.getBottom(), r.getBottom()) + uicMargin;
+
     namespace jlo = sst::jucegui::layouts;
-    auto lo = jlo::HList().at(r.getX() + uicMargin, r.getY()).withAutoGap(uicMargin * 2);
 
-    auto kl = jlo::VList().withWidth(uicKnobSize * 2 + uicMargin * 2).withAutoGap(uicMargin);
-    kl.add(titleLabelGaplessLayout(modTitle));
+    auto row1Height = uicTitleLabelInnerBox + uicMargin + uicLabeledKnobHeight;
+    auto row2Height = uicTitleLabelInnerBox + 3 * uicLabelHeight +
+                      static_cast<int>(uicLabelHeight * 1.8) + 3 * uicMargin;
 
-    auto hl = jlo::HList().withAutoGap(uicMargin).withHeight(uicLabeledKnobHeight);
-    hl.add(labelKnobLayout(envToRatio, envToRatioL));
-    hl.add(labelKnobLayout(envToRatioFine, envToRatioFineL));
-    kl.add(hl);
+    auto lo = jlo::VList().at(depx, depy).withAutoGap(uicMargin * 2);
 
-    kl.add(titleLabelGaplessLayout(lfoModTitle));
+    // Row 1: Env Depth | LFO Depth
+    auto row1 = jlo::HList().withHeight(row1Height).withAutoGap(uicMargin * 2);
 
-    hl = jlo::HList().withAutoGap(uicMargin).withHeight(uicLabeledKnobHeight);
-    hl.add(labelKnobLayout(lfoToRatio, lfoToRatioL));
-    hl.add(labelKnobLayout(lfoToRatioFine, lfoToRatioFineL));
-    kl.add(hl);
+    auto envCol = jlo::VList().withWidth(uicKnobSize * 2 + uicMargin).withAutoGap(uicMargin);
+    envCol.add(titleLabelGaplessLayout(modTitle));
+    auto ehl = jlo::HList().withAutoGap(uicMargin).withHeight(uicLabeledKnobHeight);
+    ehl.add(labelKnobLayout(envToRatio, envToRatioL));
+    ehl.add(labelKnobLayout(envToRatioFine, envToRatioFineL));
+    envCol.add(ehl);
+    row1.add(envCol);
 
-    lo.add(kl);
+    auto lfoCol = jlo::VList().withWidth(uicKnobSize * 2 + uicMargin).withAutoGap(uicMargin);
+    lfoCol.add(titleLabelGaplessLayout(lfoModTitle));
+    auto lhl = jlo::HList().withAutoGap(uicMargin).withHeight(uicLabeledKnobHeight);
+    lhl.add(labelKnobLayout(lfoToRatio, lfoToRatioL));
+    lhl.add(labelKnobLayout(lfoToRatioFine, lfoToRatioFineL));
+    lfoCol.add(lhl);
+    row1.add(lfoCol);
 
-    auto ktl = jlo::VList().withWidth(uicKnobSize * 2 + uicMargin + 36).withAutoGap(uicMargin);
-    ktl.add(titleLabelGaplessLayout(keyTrackTitle));
+    lo.add(row1);
+
+    // Row 2: Pitch | Wave
+    auto row2 = jlo::HList().withHeight(row2Height).withAutoGap(uicMargin * 2);
+
+    auto pitchCol = jlo::VList().withWidth(uicKnobSize * 2 + uicMargin + 36).withAutoGap(uicMargin);
+    pitchCol.add(titleLabelGaplessLayout(keyTrackTitle));
 
     auto sktcol = jlo::HList().withAutoGap(uicMargin).withHeight(uicLabeledKnobHeight);
 
@@ -261,8 +275,6 @@ void SourceSubPanel::resized()
     auto c2 = jlo::VList().withWidth(uicKnobSize + 18).withAutoGap(uicMargin);
     c2.add(jlo::Component(*keyTrack).withHeight(uicLabelHeight));
 
-    // We have to get a bit crunched to get this in
-    namespace jlo = sst::jucegui::layouts;
     auto ul = jlo::HList().withHeight(uicLabelHeight);
     ul.add(jlo::Component(*keyTrackLow).withWidth(20));
     ul.addGap(1);
@@ -270,14 +282,17 @@ void SourceSubPanel::resized()
     c2.add(ul);
     sktcol.add(c2);
 
-    ktl.add(sktcol);
+    pitchCol.add(sktcol);
+    row2.add(pitchCol);
 
-    ktl.add(titleLabelGaplessLayout(wavTitle));
-    ktl.add(jlo::Component(*wavButton).withHeight(uicLabelHeight));
-    ktl.add(sideLabelSlider(startingPhaseL, startingPhase));
-    ktl.add(jlo::Component(*wavPainter).withHeight(uicLabelHeight * 1.8));
+    auto waveCol = jlo::VList().withWidth(uicKnobSize * 2 + uicMargin + 36).withAutoGap(uicMargin);
+    waveCol.add(titleLabelGaplessLayout(wavTitle));
+    waveCol.add(jlo::Component(*wavButton).withHeight(uicLabelHeight));
+    waveCol.add(sideLabelSlider(startingPhaseL, startingPhase));
+    waveCol.add(jlo::Component(*wavPainter).withHeight(uicLabelHeight * 1.8));
+    row2.add(waveCol);
 
-    lo.add(ktl);
+    lo.add(row2);
 
     lo.doLayout();
 


### PR DESCRIPTION
WIth the 1.2 roadmap, I need a collection of space for some of the ideas and the UI was too cramped with the eit screen below, so move it to the side.

This looks like a massive commit but it really isn't. Its just mechanically changing hlists to vlists and stuff. The resulting layouts arent great but are on screen so I can start tweaking as I develop 1.2

It also adds a power button for macro ahead of super-macros and a vu meter for each operator, but neither is hooked up yet.

Assisted-By: claude opus 4.7