### PR TITLE
Add per-op VU meter

### DIFF
--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -167,6 +167,10 @@ void Synth::setSampleRate(double sampleRate)
 
     lagHandler.setRate(60, blockSize, monoValues.sr.sampleRate);
     vuPeak.setSampleRate(monoValues.sr.sampleRate);
+    for (int i = 0; i < numOps; ++i)
+    {
+        opVuPeak[i].setSampleRate(monoValues.sr.sampleRate);
+    }
     sampleRateRatio = hostSampleRate / engineSampleRate;
 
     if (usesLanczos())
@@ -421,15 +425,43 @@ template <bool multiOut> void Synth::processInternal(const clap_output_events_t 
 
         if (isEditorAttached)
         {
+            float stp[numOps][2][blockSize];
+            memset(stp, 0, sizeof(stp));
+            auto cvoice = head;
+            while (cvoice)
+            {
+                for (int i = 0; i < numOps; ++i)
+                {
+                    if (!cvoice->mixerNode[i].active)
+                    {
+                        continue;
+                    }
+                    mech::mul_block<blockSize>(cvoice->out.finalEnvLevel,
+                                               cvoice->mixerNode[i].output[0], stp[i][0]);
+                    mech::mul_block<blockSize>(cvoice->out.finalEnvLevel,
+                                               cvoice->mixerNode[i].output[1], stp[i][1]);
+                }
+                cvoice = cvoice->next;
+            }
             for (int i = 0; i < blockSize; ++i)
             {
                 vuPeak.process(lOutput[0][i], lOutput[1][i]);
+                for (int j = 0; j < numOps; ++j)
+                {
+                    opVuPeak[j].process(stp[j][0][i], stp[j][1][i]);
+                }
             }
 
             if (lastVuUpdate >= updateVuEvery)
             {
                 AudioToUIMsg msg{AudioToUIMsg::UPDATE_VU, 0, vuPeak.vu_peak[0], vuPeak.vu_peak[1]};
                 audioToUi.push(msg);
+                for (uint32_t j = 0; j < numOps; ++j)
+                {
+                    AudioToUIMsg smsg{AudioToUIMsg::UPDATE_VU, j + 1, opVuPeak[j].vu_peak[0],
+                                      opVuPeak[j].vu_peak[1]};
+                    audioToUi.push(smsg);
+                }
 
                 AudioToUIMsg msg2{AudioToUIMsg::UPDATE_VOICE_COUNT, (uint32_t)voiceCount};
                 audioToUi.push(msg2);

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -421,6 +421,7 @@ struct Synth
     sst::cpputils::active_set_overlay<Param> paramLagSet;
 
     sst::basic_blocks::dsp::VUPeak vuPeak;
+    std::array<sst::basic_blocks::dsp::VUPeak, numOps> opVuPeak;
     int32_t updateVuEvery{(int32_t)(48000 * 2.5 / 60 / blockSize)}; // approx
     int32_t lastVuUpdate{updateVuEvery};
 

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -235,7 +235,13 @@ void SixSinesEditor::idle()
         }
         else if (aum->action == Synth::AudioToUIMsg::UPDATE_VU)
         {
-            vuMeter->setLevels(aum->value, aum->value2);
+            assert(aum->paramId < numOps + 1);
+            if (aum->paramId == 0)
+                vuMeter->setLevels(aum->value, aum->value2);
+            else
+            {
+                mixerPanel->vuMeters[aum->paramId - 1]->setLevels(aum->value, aum->value2);
+            }
         }
         else if (aum->action == Synth::AudioToUIMsg::UPDATE_VOICE_COUNT)
         {


### PR DESCRIPTION
Re-accumulate voices in editor available mode and show the VU meter. We could special case this for multi out but I decided to keep the code simple for the most common case.