### PR TITLE
Add Step LFO shape: engine + patch complete, UI in progress

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -35,6 +35,7 @@ static constexpr size_t numMacros{6};
 static constexpr size_t maxVoices{64};
 
 static constexpr size_t numModsPer{3};
+static constexpr size_t numSeqSteps{16};
 
 extern int debugLevel;
 

--- a/src/dsp/node_support.h
+++ b/src/dsp/node_support.h
@@ -22,6 +22,8 @@
 #include "sst/cpputils/constructors.h"
 #include "sst/basic-blocks/modulators/AHDSRShapedSC.h"
 #include "sst/basic-blocks/modulators/SimpleLFO.h"
+#include "sst/basic-blocks/modulators/StepLFO.h"
+#include "sst/basic-blocks/modulators/Transport.h"
 #include "sst/basic-blocks/dsp/Lag.h"
 
 #include "synth/mono_values.h"
@@ -260,7 +262,7 @@ template <typename T> struct EnvelopeSupport
 template <typename Parent, typename T, bool needsSmoothing = true> struct LFOSupport
 {
     const T &paramBundle;
-    const MonoValues &monoValues;
+    MonoValues &monoValues; // non-const so we can read the RNG
 
     const float &lfoRate, &lfoDeform, &lfoShape, &lfoActiveV, &tempoSyncV, &bipolarV,
         &lfoIsEnvelopedV, &lfoStartPhase;
@@ -269,12 +271,36 @@ template <typename Parent, typename T, bool needsSmoothing = true> struct LFOSup
     lfo_t lfo;
     sst::basic_blocks::dsp::OnePoleLag<float, false> lag;
 
+    using stepLfo_t = sst::basic_blocks::modulators::StepLFO<blockSize>;
+    stepLfo_t stepLFO;
+    typename stepLfo_t::Storage stepStorage;
+    sst::basic_blocks::modulators::Transport stepTransport;
+    std::array<const float *, numSeqSteps> stepValues;
+    const float *stepCountValue{nullptr};
+    const float *stepCycleModeValue{nullptr};
+
     LFOSupport(const T &mn, MonoValues &mv)
-        : paramBundle(mn), lfo(&mv.sr, mv.rng), lfoRate(mn.lfoRate), lfoDeform(mn.lfoDeform),
-          lfoShape(mn.lfoShape), lfoActiveV(mn.lfoActive), tempoSyncV(mn.tempoSync), monoValues(mv),
-          bipolarV(mn.lfoBipolar), lfoIsEnvelopedV(mn.lfoIsEnveloped),
-          lfoStartPhase(mn.lfoStartPhase)
+        : paramBundle(mn), lfo(&mv.sr, mv.rng), stepLFO(mv.tuningProvider), lfoRate(mn.lfoRate),
+          lfoDeform(mn.lfoDeform), lfoShape(mn.lfoShape), lfoActiveV(mn.lfoActive),
+          tempoSyncV(mn.tempoSync), monoValues(mv), bipolarV(mn.lfoBipolar),
+          lfoIsEnvelopedV(mn.lfoIsEnveloped), lfoStartPhase(mn.lfoStartPhase),
+          stepValues(sst::cpputils::make_array_lambda<const float *, numSeqSteps>(
+              [&mn](int i) { return &mn.lfoSeqSteps[i].value; })),
+          stepCountValue(&mn.lfoStepCount.value), stepCycleModeValue(&mn.lfoCycleMode.value)
     {
+    }
+
+    void snapStepStorageFromParams()
+    {
+        for (size_t i = 0; i < numSeqSteps; ++i)
+            stepStorage.data[i] = *stepValues[i];
+        for (size_t i = numSeqSteps; i < stepLfo_t::Storage::stepLfoSteps; ++i)
+            stepStorage.data[i] = 0.f;
+        auto count = (int)std::round(*stepCountValue);
+        stepStorage.repeat = (int16_t)std::clamp(count, 1, (int)numSeqSteps);
+        auto cycleOn = stepCycleModeValue && *stepCycleModeValue > 0.5f;
+        stepStorage.rateIsForSingleStep = !cycleOn;
+        stepStorage.smooth = std::clamp(lfoDeform + lfoDeformMod, -1.f, 1.f);
     }
 
     float lfoRateMod{0.f}, lfoDeformMod{0.f}, lfoStartMod{0.f};
@@ -297,17 +323,39 @@ template <typename Parent, typename T, bool needsSmoothing = true> struct LFOSup
         lfoIsEnveloped = lfoIsEnvelopedV > 0.5;
         shape = static_cast<int>(std::round(lfoShape));
 
-        lfo.attack(shape);
-        lfo.applyPhaseOffset(lfoStartPhase + lfoStartMod);
+        // Shape is latched at attack time; lfoProcess assumes the matching
+        // oscillator was initialized here. If shape is ever allowed to change
+        // between attack and process, both branches must be reconciled.
+        if (shape == Patch::LFOMixin::Shape::Step)
+        {
+            snapStepStorageFromParams();
+            stepLFO.setSampleRate(monoValues.sr.sampleRate, monoValues.sr.sampleRateInv);
+            stepTransport.tempo = monoValues.tempoSyncRatio * 120.0;
+            auto useRate = std::clamp(lfoRate + lfoRateMod, paramBundle.lfoRate.meta.minVal,
+                                      paramBundle.lfoRate.meta.maxVal);
+            stepLFO.assign(&stepStorage, useRate, &stepTransport, monoValues.rng, tempoSync);
+
+            double phase0 =
+                std::clamp(lfoStartPhase + lfoStartMod, 0.f, 0.999f) * stepStorage.repeat;
+            double phaseFr = phase0 - std::floor(phase0);
+            stepLFO.setPhaseTo((int)std::floor(phase0), (float)phaseFr);
+        }
+        else
+        {
+            lfo.attack(shape);
+            lfo.applyPhaseOffset(lfoStartPhase + lfoStartMod);
+        }
         if (needsSmoothing)
         {
-            auto tshape = (lfo_t::Shape)shape;
+            using shp = Patch::LFOMixin::Shape;
+            auto tshape = (shp)shape;
             switch (tshape)
             {
-            case lfo_t::RAMP:
-            case lfo_t::DOWN_RAMP:
-            case lfo_t::PULSE:
-            case lfo_t::SH_NOISE:
+            case shp::Ramp:
+            case shp::Saw:
+            case shp::Pulse:
+            case shp::SandH:
+            case shp::Step:
                 doSmooth = true;
                 lag.setRateInMilliseconds(10, monoValues.sr.samplerate, 1.0);
                 lag.snapTo(0.f);
@@ -342,10 +390,23 @@ template <typename Parent, typename T, bool needsSmoothing = true> struct LFOSup
             rate = -paramBundle.lfoRate.meta.snapToTemposync(-rate);
         }
 
-        lfo.process_block(std::clamp(rate + lfoRateMod, paramBundle.lfoRate.meta.minVal,
-                                     paramBundle.lfoRate.meta.maxVal),
-                          std::clamp(lfoDeform + lfoDeformMod, -1.f, 1.f), shape, false,
-                          tempoSync ? monoValues.tempoSyncRatio : 1.0);
+        if (shape == Patch::LFOMixin::Shape::Step)
+        {
+            snapStepStorageFromParams();
+            stepTransport.tempo = monoValues.tempoSyncRatio * 120.0;
+            auto useRate = std::clamp(rate + lfoRateMod, paramBundle.lfoRate.meta.minVal,
+                                      paramBundle.lfoRate.meta.maxVal);
+            stepLFO.process(useRate, 0, tempoSync, false, blockSize);
+            for (int j = 0; j < blockSize; ++j)
+                lfo.outputBlock[j] = stepLFO.output;
+        }
+        else
+        {
+            lfo.process_block(std::clamp(rate + lfoRateMod, paramBundle.lfoRate.meta.minVal,
+                                         paramBundle.lfoRate.meta.maxVal),
+                              std::clamp(lfoDeform + lfoDeformMod, -1.f, 1.f), shape, false,
+                              tempoSync ? monoValues.tempoSyncRatio : 1.0);
+        }
 
         if constexpr (needsSmoothing)
         {
@@ -359,7 +420,7 @@ template <typename Parent, typename T, bool needsSmoothing = true> struct LFOSup
                 }
             }
         }
-        if (!bipolar)
+        if (!bipolar && shape != Patch::LFOMixin::Shape::Step)
         {
             for (int j = 0; j < blockSize; ++j)
             {

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -77,7 +77,7 @@ struct Patch : pats::PatchBase<Patch, Param>
     static constexpr uint32_t boolFlags{CLAP_PARAM_IS_AUTOMATABLE | CLAP_PARAM_IS_STEPPED};
 
     static constexpr uint64_t version_110 = 0x010100;
-    static constexpr uint64_t version_120 = 0x010201;
+    static constexpr uint64_t version_120a = 0x010201; // first chunk of 1.2.0; step sequencer
     static md_t baseMd(uint64_t version = version_110) { return md_t().withVersion(version); }
     static md_t floatMd(uint64_t version = version_110)
     {
@@ -154,7 +154,19 @@ struct Patch : pats::PatchBase<Patch, Param>
 
     struct LFOMixin
     {
-        LFOMixin(const std::string name, int id0)
+        enum Shape
+        {
+            Sine = 0,
+            Ramp,
+            Saw,
+            Triangle,
+            Pulse,
+            Noise,
+            SandH,
+            Step
+        };
+
+        LFOMixin(const std::string name, int id0, int stepid0 = -1)
             : lfoRate(floatMd()
                           .asLfoRate(-7, 11)
                           .withName(name + " LFO Rate")
@@ -170,7 +182,7 @@ struct Patch : pats::PatchBase<Patch, Param>
               lfoShape(intMd()
                            .withName(name + " LFO Shape")
                            .withGroupName(name)
-                           .withRange(0, 6)
+                           .withRange(0, 7)
                            .withDefault(0)
                            .withID(id0 + 3)
                            .withUnorderedMapFormatting({{0, "Sine"},
@@ -179,7 +191,8 @@ struct Patch : pats::PatchBase<Patch, Param>
                                                         {3, "Triangle"},
                                                         {4, "Pulse"},
                                                         {5, "Noise"},
-                                                        {6, "S and H"}})),
+                                                        {6, "S and H"},
+                                                        {7, "Step"}})),
               lfoActive(boolMd()
                             .withDefault(true)
                             .withID(id0 + 4)
@@ -207,13 +220,38 @@ struct Patch : pats::PatchBase<Patch, Param>
                                 .withName(name + " Start Phase")
                                 .withGroupName(name)
                                 .withRange(0., 1.)
-                                .withLinearScaleFormatting(""))
+                                .withLinearScaleFormatting("")),
+              lfoSeqSteps(scpu::make_array_lambda<Param, numSeqSteps>(
+                  [this, id0, stepid0, name](auto sid)
+                  {
+                      auto idv = (stepid0 > 0 ? (stepid0) : (id0 + 9)) + sid;
+                      return floatMd(version_120a)
+                          .withDefault(0)
+                          .withID(idv)
+                          .withName(name + " Seq Step " + std::to_string(sid))
+                          .withGroupName(name)
+                          .asPercentBipolar();
+                  })),
+              lfoStepCount(floatMd(version_120a)
+                               .withID((stepid0 > 0 ? (stepid0) : (id0 + 9)) + 16)
+                               .withName(name + " Step Count")
+                               .withGroupName(name)
+                               .asInt()
+                               .withRange(1, numSeqSteps)
+                               .withDefault(numSeqSteps)
+                               .withLinearScaleFormatting("steps")),
+              lfoCycleMode(boolMd(version_120a)
+                               .withName(name + " Cycle")
+                               .withDefault(0)
+                               .withGroupName(name)
+                               .withID(((stepid0 > 0 ? (stepid0) : (id0 + 9)) + 17)))
         {
             lfoRate.tempoSyncPartner = &tempoSync;
         }
 
         Param lfoRate, lfoDeform, lfoShape, lfoActive, tempoSync, lfoBipolar, lfoIsEnveloped,
-            lfoStartPhase;
+            lfoStartPhase, lfoStepCount, lfoCycleMode;
+        std::array<Param, numSeqSteps> lfoSeqSteps;
 
         void appendLFOParams(std::vector<Param *> &res)
         {
@@ -224,6 +262,12 @@ struct Patch : pats::PatchBase<Patch, Param>
             res.push_back(&lfoBipolar);
             res.push_back(&lfoIsEnveloped);
             res.push_back(&lfoStartPhase);
+            for (size_t sid = 0; sid < numSeqSteps; ++sid)
+            {
+                res.push_back(&lfoSeqSteps[sid]);
+            }
+            res.push_back(&lfoStepCount);
+            res.push_back(&lfoCycleMode);
         }
 
         enum LFOTargets
@@ -703,7 +747,8 @@ struct Patch : pats::PatchBase<Patch, Param>
                          .withGroupName(name(idx))
                          .withDefault(false)
                          .withID(id(1, idx))),
-              DAHDSRMixin(name(idx), id(2, idx), false), LFOMixin(name(idx), id(15, idx)),
+              DAHDSRMixin(name(idx), id(2, idx), false),
+              LFOMixin(name(idx), id(15, idx), id(60, idx)),
               lfoToFB(floatMd()
                           .asPercentBipolar()
                           .withName(name(idx) + " LFO to FB Amplitude")
@@ -821,7 +866,7 @@ struct Patch : pats::PatchBase<Patch, Param>
                                   .withUnorderedMapFormatting(
                                       {{0, "Signal"}, {1, "abs(Signal)"}, {2, "(1+Signal)/2"}})),
               DAHDSRMixin(name(idx), id(2, idx), false, false, id(50, idx)),
-              LFOMixin(name(idx), id(14, idx)),
+              LFOMixin(name(idx), id(14, idx), id(90, idx)),
               lfoToDepth(floatMd()
                              .asPercentBipolar()
                              .withName(name(idx) + " LFO to Depth")
@@ -945,7 +990,7 @@ struct Patch : pats::PatchBase<Patch, Param>
                       .withGroupName(name(idx))
                       .withDefault(0.f)
                       .withID(id(15, idx))),
-              LFOMixin(name(idx), id(30, idx)),
+              LFOMixin(name(idx), id(30, idx), id(65, idx)),
               lfoToLevel(floatMd()
                              .asPercentBipolar()
                              .withName(name(idx) + " LFO to Level")
@@ -1392,12 +1437,12 @@ struct Patch : pats::PatchBase<Patch, Param>
                           .withDefault(TargetID::NONE)
                           .withID(id(150 + i));
                   })),
-              LFOMixin(name(), id(200)), lfoDepth(floatMd()
-                                                      .asPercentBipolar()
-                                                      .withName(name() + " LFO Depth")
-                                                      .withGroupName(name())
-                                                      .withDefault(0)
-                                                      .withID(id(220)))
+              LFOMixin(name(), id(200), id(230)), lfoDepth(floatMd()
+                                                               .asPercentBipolar()
+                                                               .withName(name() + " LFO Depth")
+                                                               .withGroupName(name())
+                                                               .withDefault(0)
+                                                               .withID(id(220)))
         {
             defaultTrigger.adhocFeatures = Param::AdHocFeatureValues::TRIGGERMODE;
             appendLFOTargetName(targetList);

--- a/src/ui/dahdsr-components.h
+++ b/src/ui/dahdsr-components.h
@@ -101,7 +101,8 @@ template <typename Comp, typename PatchPart> struct DAHDSRComponents
 
         namespace jlo = sst::jucegui::layouts;
 
-        auto lo = jlo::VList().at(x, y).withHeight(180).withWidth(nels * uicSliderWidth);
+        auto lo =
+            jlo::VList().at(x, y).withHeight(180 - uicMargin).withWidth(nels * uicSliderWidth);
 
         lo.add(titleLabelLayout(titleLab));
         auto sliders = jlo::HList().expandToFill();

--- a/src/ui/lfo-components.h
+++ b/src/ui/lfo-components.h
@@ -21,6 +21,7 @@
 #include <sst/jucegui/components/HSliderFilled.h>
 #include <sst/jucegui/components/Label.h>
 #include <sst/jucegui/components/MultiSwitch.h>
+#include <sst/jucegui/components/JogUpDownButton.h>
 #include "patch-data-bindings.h"
 #include "ui-constants.h"
 #include "sst/jucegui/components/RuledLabel.h"
@@ -78,6 +79,28 @@ template <typename Comp, typename Patch> struct LFOComponents
         isEnv->setLabel("* Env");
         c->addAndMakeVisible(*isEnv);
 
+        for (size_t i = 0; i < numSeqSteps; ++i)
+        {
+            createComponent(e, *c, v.lfoSeqSteps[i], stepSlider[i], stepSliderD[i]);
+            c->addAndMakeVisible(*stepSlider[i]);
+            sst::jucegui::component_adapters::setTraversalId(stepSlider[i].get(), 220 + (int)i);
+        }
+        createComponent(e, *c, v.lfoStepCount, stepCount, stepCountD);
+        c->addAndMakeVisible(*stepCount);
+        sst::jucegui::component_adapters::setTraversalId(stepCount.get(), 240);
+
+        createComponent(e, *c, v.lfoCycleMode, cycleMode, cycleModeD);
+        cycleMode->setDrawMode(jcmp::ToggleButton::DrawMode::LABELED);
+        cycleMode->setLabel("cyc");
+        c->addAndMakeVisible(*cycleMode);
+        sst::jucegui::component_adapters::setTraversalId(cycleMode.get(), 241);
+
+        auto updateStep = [this]() { lfoSetEnabledState(shape->isEnabled()); };
+        shapeD->onGuiSetValue = updateStep;
+        stepCountD->onGuiSetValue = updateStep;
+        e.componentRefreshByID[v.lfoShape.meta.id] = updateStep;
+        e.componentRefreshByID[v.lfoStepCount.meta.id] = updateStep;
+
         rateD->setTemposyncPowerPartner(tempoSyncD.get());
 
         sst::jucegui::component_adapters::setTraversalId(shape.get(), 200);
@@ -86,37 +109,72 @@ template <typename Comp, typename Patch> struct LFOComponents
         sst::jucegui::component_adapters::setTraversalId(rate.get(), 203);
         sst::jucegui::component_adapters::setTraversalId(deform.get(), 205);
         sst::jucegui::component_adapters::setTraversalId(isEnv.get(), 211);
+
+        lfoSetEnabledState(true);
     }
 
-    juce::Rectangle<int> layoutLFOAt(int x, int y, int extraWidth = 0)
+    void lfoSetEnabledState(bool globallyEnabled)
+    {
+        if (!shape)
+            return;
+        auto isStep = ((int)std::round(shapeD->getValue()) == 7);
+        auto count = (int)std::round(stepCountD->getValue());
+
+        rate->setEnabled(globallyEnabled);
+        deform->setEnabled(globallyEnabled);
+        phase->setEnabled(globallyEnabled);
+        shape->setEnabled(globallyEnabled);
+        tempoSync->setEnabled(globallyEnabled);
+        bipolar->setEnabled(globallyEnabled && !isStep);
+        isEnv->setEnabled(globallyEnabled);
+        stepCount->setEnabled(globallyEnabled && isStep);
+        cycleMode->setEnabled(globallyEnabled && isStep);
+        for (size_t i = 0; i < numSeqSteps; ++i)
+            stepSlider[i]->setEnabled(globallyEnabled && isStep && (int)i < count);
+
+        asComp()->repaint();
+    }
+
+    juce::Rectangle<int> layoutLFOAt(int x, int y, int width = -1)
     {
         if (!titleLab)
             return {};
 
         namespace jlo = sst::jucegui::layouts;
 
-        auto lo = jlo::VList()
-                      .at(x, y)
-                      .withHeight(asComp()->getHeight() - y)
-                      .withWidth(uicKnobSize * 2.75 + uicMargin);
+        auto w = (width > 0) ? width : (asComp()->getWidth() - x - uicMargin);
+        auto h = 180;
+
+        auto lo = jlo::VList().at(x, y).withHeight(h).withWidth(w);
 
         lo.add(titleLabelLayout(titleLab));
 
         auto columns = jlo::HList().expandToFill().withAutoGap(uicMargin);
 
         auto col1 = jlo::VList().withWidth(uicKnobSize * 1.5).withAutoGap(uicMargin);
-        col1.add(jlo::Component(*shape).withHeight(2 * uicLabeledKnobHeight - uicLabelHeight));
-        col1.add(jlo::Component(*tempoSync).withHeight(uicLabelHeight));
+        col1.add(jlo::Component(*shape).withHeight(uicLabeledKnobHeight + 3 * uicMargin +
+                                                   3 * uicLabelHeight));
         col1.add(jlo::Component(*bipolar).withHeight(uicLabelHeight));
 
         auto col2 = jlo::VList().withWidth(uicKnobSize * 1.25).withAutoGap(uicMargin);
         col2.add(labelKnobLayout(rate, rateL).centerInParent());
+        col2.add(jlo::Component(*tempoSync).withHeight(uicLabelHeight));
         col2.add(sideLabelSlider(deformL, deform));
         col2.add(sideLabelSlider(phaseL, phase));
         col2.add(jlo::Component(*isEnv).withHeight(uicLabelHeight));
 
+        auto col3 = jlo::VList().expandToFill().withAutoGap(0);
+        for (size_t i = 0; i < numSeqSteps; ++i)
+            col3.add(jlo::Component(*stepSlider[i]).expandToFill());
+        col3.addGap(uicMargin);
+        auto bottomRow = jlo::HList().withHeight(uicLabelHeight).withAutoGap(uicMargin);
+        bottomRow.add(jlo::Component(*stepCount).withWidth(70));
+        bottomRow.add(jlo::Component(*cycleMode).expandToFill());
+        col3.add(bottomRow);
+
         columns.add(col1);
         columns.add(col2);
+        columns.add(col3);
 
         lo.add(columns);
 
@@ -141,6 +199,15 @@ template <typename Comp, typename Patch> struct LFOComponents
 
     std::unique_ptr<jcmp::ToggleButton> isEnv;
     std::unique_ptr<PatchDiscrete> isEnvD;
+
+    std::array<std::unique_ptr<jcmp::HSliderFilled>, numSeqSteps> stepSlider;
+    std::array<std::unique_ptr<PatchContinuous>, numSeqSteps> stepSliderD;
+
+    std::unique_ptr<jcmp::JogUpDownButton> stepCount;
+    std::unique_ptr<PatchDiscrete> stepCountD;
+
+    std::unique_ptr<jcmp::ToggleButton> cycleMode;
+    std::unique_ptr<PatchDiscrete> cycleModeD;
 };
 } // namespace baconpaul::six_sines::ui
 #endif // LFO_COMPONENTS_H

--- a/src/ui/source-sub-panel.cpp
+++ b/src/ui/source-sub-panel.cpp
@@ -333,13 +333,7 @@ void SourceSubPanel::setEnabledState()
     triggerButton->setEnabled(!isAudioIn);
 
     // LFO controls
-    rate->setEnabled(!isAudioIn);
-    deform->setEnabled(!isAudioIn);
-    phase->setEnabled(!isAudioIn);
-    shape->setEnabled(!isAudioIn);
-    tempoSync->setEnabled(!isAudioIn);
-    bipolar->setEnabled(!isAudioIn);
-    isEnv->setEnabled(!isAudioIn);
+    lfoSetEnabledState(!isAudioIn);
 
     // Modulation slots
     for (int i = 0; i < numModsPer; ++i)


### PR DESCRIPTION
Add a 16 step ShortCircuit step sequencer complete with phase modifiation and deform. The UI is just a slider stack now which stinks but I'll get that in the next commit. This does the patch, plumbing, and engine work needed to get started

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>