### PR TITLE
Go hunting uninitialized members

### DIFF
--- a/cmake/compile-options.cmake
+++ b/cmake/compile-options.cmake
@@ -22,6 +22,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
     add_compile_options(
             $<$<BOOL:${USE_SANITIZER}>:-fsanitize=address>
             $<$<BOOL:${USE_SANITIZER}>:-fsanitize=undefined>
+            $<$<BOOL:${USE_SANITIZER}>:-fno-sanitize-recover=undefined>
+            $<$<BOOL:${USE_SANITIZER}>:-fsanitize-address-use-after-scope>
+            # Fill stack/heap uninitialized locals with a repeating pattern so
+            # uninit reads surface deterministically on macOS/Linux rather than
+            # happening to read as zero
+            $<$<BOOL:${USE_SANITIZER}>:-ftrivial-auto-var-init=pattern>
 
             $<$<OR:$<COMPILE_LANGUAGE:CXX>,$<COMPILE_LANGUAGE:OBJC>,$<COMPILE_LANGUAGE:OBJCXX>>:-fno-char8_t>
     )
@@ -29,6 +35,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
     add_link_options(
             $<$<BOOL:${USE_SANITIZER}>:-fsanitize=address>
             $<$<BOOL:${USE_SANITIZER}>:-fsanitize=undefined>
+            $<$<BOOL:${USE_SANITIZER}>:-fno-sanitize-recover=undefined>
     )
     if (NOT APPLE)
         add_compile_options($<IF:$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},aarch64>,-march=armv8-a,-march=nehalem>)

--- a/src/dsp/node_support.h
+++ b/src/dsp/node_support.h
@@ -305,7 +305,7 @@ template <typename Parent, typename T, bool needsSmoothing = true> struct LFOSup
 
     float lfoRateMod{0.f}, lfoDeformMod{0.f}, lfoStartMod{0.f};
 
-    int shape;
+    int shape{0};
     bool tempoSync{false};
     bool bipolar{true};
     bool lfoIsEnveloped{false};
@@ -467,7 +467,7 @@ template <typename Bundle, typename Node> struct ModulationSupport
     std::array<const float *, numModsPer> depthPointers;
     std::array<float, numModsPer> priorModulation;
 
-    float modr01, modrpm1, modrnorm, modrhalfnorm;
+    float modr01{0.f}, modrpm1{0.f}, modrnorm{0.f}, modrhalfnorm{0.f};
 
     ModulationSupport(const Bundle &mn, Node *p, MonoValues &mv, const VoiceValues &vv)
         : paramBundle(mn), enclosingNode(p), monoValues(mv), voiceValues(vv),

--- a/src/dsp/op_source.h
+++ b/src/dsp/op_source.h
@@ -56,8 +56,8 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
 
     // todo waveshape
 
-    uint32_t phase;
-    int32_t dPhase;
+    uint32_t phase{0};
+    int32_t dPhase{0};
 
     static constexpr float centsScale{1.0 / (12 * 100)};
 
@@ -285,8 +285,8 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
     static constexpr int softPhaseCount{16};
     static constexpr float dSoftPhase{1.f / (blockSize * softPhaseCount)};
     int softResetPhaseCount{-1};
-    uint32_t softPhase;
-    float softFb[2];
+    uint32_t softPhase{0};
+    float softFb[2]{0.f, 0.f};
     void softResetPhase()
     {
         softPhase = 4 << 27;

--- a/src/synth/voice_values.h
+++ b/src/synth/voice_values.h
@@ -29,7 +29,7 @@ struct VoiceValues
     VoiceValues() : gated(gatedV), key(keyV) {}
 
     const bool &gated;
-    float gatedFloat, ungatedFloat;
+    float gatedFloat{0.f}, ungatedFloat{1.f};
     void setGated(bool g)
     {
         gatedV = g;
@@ -42,7 +42,7 @@ struct VoiceValues
         keytrackFrom60 = (k - 60) / 12.0;
     }
     const int &key;
-    float keytrackFrom60;
+    float keytrackFrom60{0.f};
     int channel{0};
     float velocity{0}, releaseVelocity{0};
 


### PR DESCRIPTION
With LFO we get a crash on load old projects win not mac. Using code analysis tools to look for uninitiqlized variables (the most common cause of such problems) found a case where shape was uninitialized which could lead to an incorrect step sequencer call, but would not have been harmful with just simple LFO.

While in there, initialize a few more things just for clarity

Assisted-By: Claude Opus 4.7