### PR TITLE
Heap-allocate Patch in stateLoad/presetLoadFromLocation

### DIFF
--- a/src/clap/six-sines-clap.cpp
+++ b/src/clap/six-sines-clap.cpp
@@ -319,16 +319,16 @@ struct SixSinesClap : public plugHelper_t, sst::clap_juce_shim::EditorProvider
     }
     bool stateLoad(const clap_istream *istream) noexcept override
     {
-        Patch patchCopy;
+        auto patchCopy = std::make_unique<Patch>();
         loadedDawExtraState = Synth::DawExtraState{};
-        patchCopy.dawExtraStateFrom = [this](TiXmlElement &e)
+        patchCopy->dawExtraStateFrom = [this](TiXmlElement &e)
         { Synth::fromDawExtraState(e, loadedDawExtraState); };
 
-        if (!sst::plugininfra::patch_support::inStreamToPatch(istream, patchCopy))
+        if (!sst::plugininfra::patch_support::inStreamToPatch(istream, *patchCopy))
             return false;
 
-        presets::PresetManager::sendEntirePatchToAudio(patchCopy, engine->mainToAudio,
-                                                       patchCopy.name, _host.host());
+        presets::PresetManager::sendEntirePatchToAudio(*patchCopy, engine->mainToAudio,
+                                                       patchCopy->name, _host.host());
 
         Synth::MainToAudioMsg des{Synth::MainToAudioMsg::SET_DAW_EXTRA_STATE};
         des.dawExtraStatePointer = &loadedDawExtraState;
@@ -396,12 +396,12 @@ struct SixSinesClap : public plugHelper_t, sst::clap_juce_shim::EditorProvider
                     std::stringstream buffer;
                     buffer << t.rdbuf();
 
-                    Patch patchCopy;
-                    patchCopy.fromState(buffer.str());
+                    auto patchCopy = std::make_unique<Patch>();
+                    patchCopy->fromState(buffer.str());
 
                     auto dn = p.filename().replace_extension("").u8string();
-                    presets::PresetManager::sendEntirePatchToAudio(patchCopy, engine->mainToAudio,
-                                                                   patchCopy.name, _host.host());
+                    presets::PresetManager::sendEntirePatchToAudio(*patchCopy, engine->mainToAudio,
+                                                                   patchCopy->name, _host.host());
                     return true;
                 }
                 else
@@ -426,8 +426,8 @@ struct SixSinesClap : public plugHelper_t, sst::clap_juce_shim::EditorProvider
             auto &p = pm.factoryPatchVector[idx];
 
             // TODO : Assert the keys match here
-            Patch patchCopy;
-            pm.loadFactoryPreset(patchCopy, engine->mainToAudio, p.first, p.second);
+            auto patchCopy = std::make_unique<Patch>();
+            pm.loadFactoryPreset(*patchCopy, engine->mainToAudio, p.first, p.second);
             return true;
         }
         return false;


### PR DESCRIPTION
The CLAP stateLoad callback and the preset-load path both constructed a full Patch on the caller's stack. With numSeqSteps=16 in the patch (introduced with the step LFO in #340), Patch has roughly 2000 Params, each ~400-500 bytes of inline md_t storage. That puts the stack copy close to 1 MB - right at Windows' default thread stack size for the host-provided callback thread, which made loading an old DAW session crash on Windows only. macOS has an 8 MB default stack and didn't hit the limit, and ASAN doesn't catch stack overflow.

Moving these three Patch instances to std::make_unique<Patch>() takes the Patch body off the stack entirely.

Assisted-by: Claude Opus 4.7