### PR TITLE
SuperMacro: per-voice macro modulators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(${PROJECT_NAME}-impl STATIC
         src/ui/source-panel.cpp
         src/ui/source-sub-panel.cpp
         src/ui/macro-panel.cpp
+        src/ui/macro-sub-panel.cpp
         src/ui/finetune-sub-panel.cpp
         src/ui/mainpan-sub-panel.cpp
         src/ui/playmode-sub-panel.cpp
@@ -63,6 +64,7 @@ add_library(${PROJECT_NAME}-impl STATIC
         src/synth/voice.cpp
         src/synth/patch.cpp
         src/synth/mod_matrix.cpp
+        src/synth/macro_usage.cpp
 
 )
 target_include_directories(${PROJECT_NAME}-impl PUBLIC src)

--- a/src/clap/six-sines-clap.cpp
+++ b/src/clap/six-sines-clap.cpp
@@ -346,7 +346,31 @@ struct SixSinesClap : public plugHelper_t, sst::clap_juce_shim::EditorProvider
     uint32_t paramsCount() const noexcept override { return engine->patch.params.size(); }
     bool paramsInfo(uint32_t paramIndex, clap_param_info *info) const noexcept override
     {
-        return sst::plugininfra::patch_support::patchParamsInfo(paramIndex, info, engine->patch);
+        auto ok = sst::plugininfra::patch_support::patchParamsInfo(paramIndex, info, engine->patch);
+        if (!ok)
+            return ok;
+
+        // The macro amplitude param is tagged with isPrimaryMacroFeature; for that
+        // single param swap the host-displayed name to "Foo (Macro N)" when the
+        // user has renamed the macro. Every other macro param is left alone.
+        auto *param = static_cast<const Param *>(info->cookie);
+        if (param && param->meta.hasFeature(isPrimaryMacroFeature))
+        {
+            int idx = (info->id - Patch::MacroNode::idBase) / Patch::MacroNode::idStride;
+            if (idx >= 0 && idx < (int)numMacros)
+            {
+                const auto &nameBuf = engine->patch.macroNames[idx];
+                std::string userName(nameBuf.data());
+                auto def = Patch::MacroNode::defaultGroupName(idx);
+                if (!userName.empty() && userName != def)
+                {
+                    auto fullName = userName + " (" + def + ")";
+                    strncpy(info->name, fullName.c_str(), CLAP_NAME_SIZE - 1);
+                    info->name[CLAP_NAME_SIZE - 1] = 0;
+                }
+            }
+        }
+        return ok;
     }
     bool paramsValue(clap_id paramId, double *value) noexcept override
     {

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -27,7 +27,7 @@ namespace baconpaul::six_sines
 {
 
 static constexpr size_t blockSize{8};
-static constexpr double blockSizeInv{1.0/8};
+static constexpr double blockSizeInv{1.0 / 8};
 
 static constexpr size_t numOps{6};
 static constexpr size_t matrixSize{(numOps * (numOps - 1)) / 2};

--- a/src/dsp/macro_node.h
+++ b/src/dsp/macro_node.h
@@ -1,0 +1,157 @@
+/*
+ * Six Sines
+ *
+ * A synth with audio rate modulation.
+ *
+ * Copyright 2024-2025, Paul Walker and Various authors, as described in the github
+ * transaction log.
+ *
+ * This source repo is released under the MIT license, but has
+ * GPL3 dependencies, as such the combined work will be
+ * released under GPL3.
+ *
+ * The source code and license are at https://github.com/baconpaul/six-sines
+ */
+
+#ifndef BACONPAUL_SIX_SINES_DSP_MACRO_NODE_H
+#define BACONPAUL_SIX_SINES_DSP_MACRO_NODE_H
+
+#include <algorithm>
+#include "sst/basic-blocks/mechanics/block-ops.h"
+#include "dsp/node_support.h"
+#include "synth/patch.h"
+#include "synth/mono_values.h"
+#include "synth/voice_values.h"
+
+namespace baconpaul::six_sines
+{
+namespace mech = sst::basic_blocks::mechanics;
+
+/*
+ * MacroVoiceNode — per-voice node that processes one macro's envelope + LFO + modulation
+ * when the macro's power button (macroPower) is enabled. When power is off, the node
+ * simply mirrors the static mono level.
+ */
+struct MacroVoiceNode : EnvelopeSupport<Patch::MacroNode>,
+                        LFOSupport<MacroVoiceNode, Patch::MacroNode>,
+                        ModulationSupport<Patch::MacroNode, MacroVoiceNode>
+{
+    const Patch::MacroNode &macroNode;
+    const MonoValues &monoValues;
+    const VoiceValues &voiceValues;
+    const float &level;
+    const float &macroPowerV; // mn.macroPower — distinct from EnvelopeSupport::powerV (envPower)
+    const float &envDepth;
+    const float &lfoDepth;
+
+    float out{0.f};
+    bool macroPowerOn{false};
+    bool wasPowerOn{false};
+
+    MacroVoiceNode(const Patch::MacroNode &mn, MonoValues &mv, const VoiceValues &vv)
+        : macroNode(mn), monoValues(mv), voiceValues(vv), level(mn.level),
+          macroPowerV(mn.macroPower), envDepth(mn.envDepth), lfoDepth(mn.lfoDepth),
+          ModulationSupport(mn, this, mv, vv), EnvelopeSupport(mn, mv, vv), LFOSupport(mn, mv)
+    {
+    }
+
+    void attack()
+    {
+        resetModulation();
+        envResetMod();
+        lfoResetMod();
+        bindModulation();
+        macroPowerOn = macroPowerV > 0.5f;
+        wasPowerOn = macroPowerOn;
+        if (macroPowerOn)
+        {
+            calculateModulation();
+            envAttack();
+            lfoAttack();
+        }
+    }
+
+    void process()
+    {
+        if (!macroPowerOn)
+        {
+            out = level;
+            return;
+        }
+        calculateModulation();
+        envProcess();
+        lfoProcess();
+        // outputCache, not outBlock0: envAttack's constantEnv path (the macro
+        // default) writes outputCache directly and never sets outBlock0.
+        auto envOut = env.outputCache[blockSize - 1];
+        auto lfoOut = lfo.outputBlock[blockSize - 1];
+        if (lfoIsEnveloped)
+            lfoOut *= envOut;
+        auto amp = std::clamp(level + levMod, -1.f, 1.f);
+        auto lfoContrib = lfoOut * lfoDepth * lfoAtten;
+        float result;
+        if (envIsMult)
+            result = amp * envOut * depthAtten + lfoContrib;
+        else
+            result = amp + envDepth * envOut * depthAtten + lfoContrib;
+        out = std::clamp(result, -1.f, 1.f);
+    }
+
+    float levMod{0.f};
+    float depthAtten{1.f};
+    float lfoAtten{1.f};
+
+    void resetModulation()
+    {
+        levMod = 0.f;
+        depthAtten = 1.f;
+        lfoAtten = 1.f;
+    }
+
+    void calculateModulation()
+    {
+        resetModulation();
+        envResetMod();
+        lfoResetMod();
+
+        if (!anySources)
+            return;
+
+        for (int i = 0; i < numModsPer; ++i)
+        {
+            if (sourcePointers[i] &&
+                (int)macroNode.modtarget[i].value != Patch::MacroNode::TargetID::NONE)
+            {
+                auto dp = depthPointers[i];
+                if (!dp)
+                    continue;
+                auto d = *dp;
+
+                auto handled = envHandleModulationValue((int)macroNode.modtarget[i].value, d,
+                                                        sourcePointers[i]) ||
+                               lfoHandleModulationValue((int)macroNode.modtarget[i].value, d,
+                                                        sourcePointers[i]);
+
+                if (!handled)
+                {
+                    switch ((Patch::MacroNode::TargetID)macroNode.modtarget[i].value)
+                    {
+                    case Patch::MacroNode::LEVEL:
+                        levMod += d * *sourcePointers[i];
+                        break;
+                    case Patch::MacroNode::DEPTH_ATTEN:
+                        depthAtten *= 1.0 - d * (1.0 - std::clamp(*sourcePointers[i], 0.f, 1.f));
+                        break;
+                    default:
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    bool checkLfoUsed() { return lfoDepth != 0 || lfoUsedAsModulationSource; }
+};
+
+} // namespace baconpaul::six_sines
+#endif // BACONPAUL_SIX_SINES_DSP_MACRO_NODE_H

--- a/src/dsp/node_support.h
+++ b/src/dsp/node_support.h
@@ -16,8 +16,10 @@
 #ifndef BACONPAUL_SIX_SINES_DSP_NODE_SUPPORT_H
 #define BACONPAUL_SIX_SINES_DSP_NODE_SUPPORT_H
 
+#include <cassert>
 #include <cstring>
 #include <string.h>
+#include <type_traits>
 
 #include "sst/cpputils/constructors.h"
 #include "sst/basic-blocks/modulators/AHDSRShapedSC.h"
@@ -532,6 +534,25 @@ template <typename Bundle, typename Node> struct ModulationSupport
             sv < ModMatrixConfig::Source::MACRO_0 + numMacros)
         {
             sourcePointers[which] = monoValues.macroPtr[sv - ModMatrixConfig::Source::MACRO_0];
+            return;
+        }
+
+        if (sv >= ModMatrixConfig::Source::MACRO_MOD_0 &&
+            sv < ModMatrixConfig::Source::MACRO_MOD_0 + numMacros)
+        {
+            // Macros are processed in index order; reading a higher-indexed
+            // MACRO_MOD_k would see last block's value. UI prevents this;
+            // assert catches a malformed patch.
+#ifndef NDEBUG
+            if constexpr (std::is_same_v<Bundle, Patch::MacroNode>)
+            {
+                int mySrcIdx = sv - ModMatrixConfig::Source::MACRO_MOD_0;
+                assert(mySrcIdx < paramBundle.index &&
+                       "macro mod-source must reference a lower-indexed macro");
+            }
+#endif
+            sourcePointers[which] =
+                &voiceValues.macroOut[sv - ModMatrixConfig::Source::MACRO_MOD_0];
             return;
         }
 

--- a/src/presets/preset-manager.cpp
+++ b/src/presets/preset-manager.cpp
@@ -266,6 +266,21 @@ void PresetManager::sendEntirePatchToAudio(Patch &patch, Synth::mainToAudioQueue
     memset(tmpDat, 0, 128 * sizeof(char));
     strncpy(tmpDat, name.c_str(), 255);
     mainToAudio.push({Synth::MainToAudioMsg::SEND_PATCH_NAME, 0, 0.f, tmpDat});
+
+    // Each macro name uses its own slot in the rotating buffer so the pointer
+    // stays valid until the audio thread drains the queue.
+    for (uint32_t mi = 0; mi < numMacros; ++mi)
+    {
+        char *macDat = stringBuffer[currentString];
+        currentString = (currentString + 1) % 128;
+        memset(macDat, 0, 256);
+        strncpy(macDat, patch.macroNames[mi].data(), 255);
+        Synth::MainToAudioMsg msg{Synth::MainToAudioMsg::SEND_MACRO_NAME};
+        msg.paramId = mi;
+        msg.uiManagedPointer = macDat;
+        mainToAudio.push(msg);
+    }
+
     mainToAudio.push({Synth::MainToAudioMsg::STOP_AUDIO});
     for (const auto &p : patch.params)
     {

--- a/src/synth/macro_usage.cpp
+++ b/src/synth/macro_usage.cpp
@@ -1,0 +1,102 @@
+/*
+ * Six Sines
+ *
+ * A synth with audio rate modulation.
+ *
+ * Copyright 2024-2025, Paul Walker and Various authors, as described in the github
+ * transaction log.
+ *
+ * This source repo is released under the MIT license, but has
+ * GPL3 dependencies, as such the combined work will be
+ * released under GPL3.
+ *
+ * The source code and license are at https://github.com/baconpaul/six-sines
+ */
+
+#include "macro_usage.h"
+#include "patch.h"
+#include "matrix_index.h"
+#include "mod_matrix.h"
+
+namespace baconpaul::six_sines
+{
+
+namespace
+{
+template <typename Node>
+void scanNode(const Node &node, MacroUsedRef::NodeKind kind, int nodeIndex,
+              const std::string &nodeLabel,
+              std::array<std::vector<MacroUsedRef>, numMacros> &result)
+{
+    for (int s = 0; s < numModsPer; ++s)
+    {
+        auto src = static_cast<int>(std::round(node.modsource[s].value));
+        auto tgt = static_cast<int>(std::round(node.modtarget[s].value));
+        if (tgt == 0 /* NONE */ || src == ModMatrixConfig::Source::OFF)
+            continue;
+
+        int macroIdx = -1;
+        bool modulated = false;
+        if (src >= ModMatrixConfig::Source::MACRO_0 &&
+            src < ModMatrixConfig::Source::MACRO_0 + (int)numMacros)
+        {
+            macroIdx = src - ModMatrixConfig::Source::MACRO_0;
+            modulated = false;
+        }
+        else if (src >= ModMatrixConfig::Source::MACRO_MOD_0 &&
+                 src < ModMatrixConfig::Source::MACRO_MOD_0 + (int)numMacros)
+        {
+            macroIdx = src - ModMatrixConfig::Source::MACRO_MOD_0;
+            modulated = true;
+        }
+        if (macroIdx < 0)
+            continue;
+
+        std::string targetName{"?"};
+        for (auto &[id, nm] : node.targetList)
+        {
+            if (id == tgt)
+            {
+                targetName = nm;
+                break;
+            }
+        }
+
+        result[macroIdx].push_back({kind, nodeIndex, nodeLabel, modulated, targetName});
+    }
+}
+} // namespace
+
+std::array<std::vector<MacroUsedRef>, numMacros> computeMacroUsage(const Patch &p)
+{
+    std::array<std::vector<MacroUsedRef>, numMacros> result;
+
+    using K = MacroUsedRef::NodeKind;
+    for (int i = 0; i < numOps; ++i)
+    {
+        scanNode(p.sourceNodes[i], K::SourceOp, i, "Op " + std::to_string(i + 1) + " Source",
+                 result);
+        scanNode(p.selfNodes[i], K::SelfOp, i, "Op " + std::to_string(i + 1) + " Self", result);
+        scanNode(p.mixerNodes[i], K::MixerOp, i, "Op " + std::to_string(i + 1) + " Mixer", result);
+    }
+    for (int i = 0; i < (int)matrixSize; ++i)
+    {
+        auto srcOp = MatrixIndex::sourceIndexAt(i);
+        auto tgtOp = MatrixIndex::targetIndexAt(i);
+        scanNode(p.matrixNodes[i], K::Matrix, i,
+                 "Op " + std::to_string(srcOp + 1) + " " + u8"\U00002192" + " Op " +
+                     std::to_string(tgtOp + 1),
+                 result);
+    }
+    for (int i = 0; i < numMacros; ++i)
+    {
+        scanNode(p.macroNodes[i], K::Macro, i, "Macro " + std::to_string(i + 1), result);
+    }
+    scanNode(p.output, K::MainOutput, 0, "Main Output", result);
+    scanNode(p.fineTuneMod, K::FineTune, 0, "Main Tuning", result);
+    scanNode(p.mainPanMod, K::MainPan, 0, "Main Pan", result);
+
+    return result;
+}
+
+} // namespace baconpaul::six_sines

--- a/src/synth/macro_usage.h
+++ b/src/synth/macro_usage.h
@@ -1,0 +1,56 @@
+/*
+ * Six Sines
+ *
+ * A synth with audio rate modulation.
+ *
+ * Copyright 2024-2025, Paul Walker and Various authors, as described in the github
+ * transaction log.
+ *
+ * This source repo is released under the MIT license, but has
+ * GPL3 dependencies, as such the combined work will be
+ * released under GPL3.
+ *
+ * The source code and license are at https://github.com/baconpaul/six-sines
+ */
+
+#ifndef BACONPAUL_SIX_SINES_SYNTH_MACRO_USAGE_H
+#define BACONPAUL_SIX_SINES_SYNTH_MACRO_USAGE_H
+
+#include <array>
+#include <vector>
+#include <string>
+#include "configuration.h"
+
+namespace baconpaul::six_sines
+{
+struct Patch;
+
+// One consumer of a macro. UI renders as [jump button] [nodeLabel] [mod/amp]
+// [targetName]; kind+index drives the jump button.
+struct MacroUsedRef
+{
+    enum class NodeKind
+    {
+        SourceOp,   // sourcePanel->beginEdit(index)
+        SelfOp,     // matrixPanel->beginEdit(index, true)
+        MixerOp,    // mixerPanel->beginEdit(index)
+        Matrix,     // matrixPanel->beginEdit(index, false)
+        Macro,      // macroPanel->beginEdit(index)
+        MainOutput, // mainPanel->beginEdit(0)
+        MainPan,    // mainPanel->beginEdit(1)
+        FineTune    // mainPanel->beginEdit(2)
+    };
+    NodeKind kind;
+    int index;              // op idx / matrix slot / macro idx; ignored for singletons
+    std::string nodeLabel;  // "Op 1 → Op 3", "Op 1 Self", "Macro 2", "Main Output"
+    bool modulated;         // true = MACRO_MOD source, false = MACRO (amp)
+    std::string targetName; // "Level", "LFO Rate", ...
+};
+
+// Walk every modsource[] across the patch and bucket each active reference
+// to MACRO_n / MACRO_MOD_n into the corresponding macro's list. A slot is
+// "active" if its modtarget is not NONE.
+std::array<std::vector<MacroUsedRef>, numMacros> computeMacroUsage(const Patch &p);
+} // namespace baconpaul::six_sines
+
+#endif // BACONPAUL_SIX_SINES_SYNTH_MACRO_USAGE_H

--- a/src/synth/mod_matrix.cpp
+++ b/src/synth/mod_matrix.cpp
@@ -45,7 +45,9 @@ ModMatrixConfig::ModMatrixConfig()
         add(MIDICC_0 + cc, "MIDI CC", q);
     }
     for (int mc = 0; mc < numMacros; ++mc)
-        add(MACRO_0 + mc, "Macros", "Macro " + std::to_string(mc + 1));
+        add(MACRO_0 + mc, "Macros", "Macro " + std::to_string(mc + 1) + " Amplitude");
+    for (int mc = 0; mc < numMacros; ++mc)
+        add(MACRO_MOD_0 + mc, "Macros", "Macro " + std::to_string(mc + 1) + " Modulated");
 
     add(VELOCITY, "MIDI", "Velocity");
     add(RELEASE_VELOCITY, "MIDI", "Release Velocity");
@@ -75,6 +77,27 @@ ModMatrixConfig::ModMatrixConfig()
                       return a.name < b.name;
                   return a.id < b.id;
               });
+
+    // Within the Macros group: amplitudes first (by index), separator, then
+    // modulated entries (by index). Default alphabetical sort interleaves them.
+    auto isMacroAmp = [](const SourceObj &o)
+    { return o.id >= MACRO_0 && o.id < MACRO_0 + (int)numMacros; };
+    auto isMacroMod = [](const SourceObj &o)
+    { return o.id >= MACRO_MOD_0 && o.id < MACRO_MOD_0 + (int)numMacros; };
+    auto isMacro = [&](const SourceObj &o) { return isMacroAmp(o) || isMacroMod(o); };
+    auto firstMacro = std::find_if(sources.begin(), sources.end(), isMacro);
+    auto lastMacro =
+        std::find_if(firstMacro, sources.end(), [&](const SourceObj &o) { return !isMacro(o); });
+    if (firstMacro != lastMacro)
+    {
+        std::stable_partition(firstMacro, lastMacro, isMacroAmp);
+        std::sort(firstMacro, lastMacro,
+                  [](const SourceObj &a, const SourceObj &b) { return a.id < b.id; });
+        auto firstMod = std::find_if(firstMacro, lastMacro, isMacroMod);
+        if (firstMod != lastMacro)
+            firstMod->addSeparatorBefore = true;
+    }
+
     for (auto &s : sources)
     {
         sourceByID[s.id] = s;

--- a/src/synth/mod_matrix.h
+++ b/src/synth/mod_matrix.h
@@ -40,7 +40,8 @@ struct ModMatrixConfig
         MIDICC_0 = 200, // leave 126 gap after this
 
         // Macros
-        MACRO_0 = 400, // leave numMacros gap after this
+        MACRO_0 = 400,     // leave numMacros gap after this
+        MACRO_MOD_0 = 410, // leave numMacros gap after this
 
         // Voice level
         VELOCITY = voiceLevel + 0,
@@ -71,6 +72,7 @@ struct ModMatrixConfig
         int id;
         std::string group;
         std::string name;
+        bool addSeparatorBefore{false}; // render hint: insert a menu separator before this entry
     };
     std::vector<SourceObj> sources;
     std::unordered_map<uint32_t, SourceObj> sourceByID;

--- a/src/synth/patch.cpp
+++ b/src/synth/patch.cpp
@@ -17,6 +17,61 @@
 namespace baconpaul::six_sines
 {
 
+void Patch::setupAdditionalState()
+{
+    onResetToInit = [](Patch &p)
+    {
+        for (int i = 0; i < numMacros; ++i)
+        {
+            auto s = "Macro " + std::to_string(i + 1);
+            strncpy(p.macroNames[i].data(), s.c_str(), 63);
+            p.macroNames[i][63] = '\0';
+        }
+    };
+
+    additionalToState = [this](TiXmlElement &root)
+    {
+        TiXmlElement mn("macroNames");
+        for (int i = 0; i < numMacros; ++i)
+        {
+            TiXmlElement entry("macroName");
+            entry.SetAttribute("idx", i);
+            TiXmlText t(macroNames[i].data());
+            t.SetCDATA(true);
+            entry.InsertEndChild(t);
+            mn.InsertEndChild(entry);
+        }
+        root.InsertEndChild(mn);
+    };
+
+    additionalFromState = [this](TiXmlElement *root, uint32_t /*ver*/)
+    {
+        auto *mn = root->FirstChildElement("macroNames");
+        if (!mn)
+            return;
+        auto *entry = mn->FirstChildElement("macroName");
+        while (entry)
+        {
+            int idx = -1;
+            if (entry->QueryIntAttribute("idx", &idx) == TIXML_SUCCESS && idx >= 0 &&
+                idx < numMacros)
+            {
+                auto *n = entry->FirstChild();
+                if (n)
+                {
+                    auto *txt = n->ToText();
+                    if (txt && txt->Value())
+                    {
+                        strncpy(macroNames[idx].data(), txt->Value(), 63);
+                        macroNames[idx][63] = '\0';
+                    }
+                }
+            }
+            entry = entry->NextSiblingElement("macroName");
+        }
+    };
+}
+
 float Patch::migrateParamValueFromVersion(Param *p, float value, uint32_t version)
 {
     if ((p->adhocFeatures & Param::AdHocFeatureValues::ENVTIME) && version <= 2)

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -36,6 +36,9 @@ namespace baconpaul::six_sines
 namespace scpu = sst::cpputils;
 namespace pats = sst::plugininfra::patch_support;
 using md_t = sst::basic_blocks::params::ParamMetaData;
+
+static constexpr uint64_t isPrimaryMacroFeature = (uint64_t)md_t::Features::USER_FEATURE_0;
+
 struct Param : pats::ParamBase, sst::cpputils::active_set_overlay<Param>::participant
 {
     Param(const md_t &m) : pats::ParamBase(m) {}
@@ -77,9 +80,12 @@ struct Patch : pats::PatchBase<Patch, Param>
     static constexpr uint32_t boolFlags{CLAP_PARAM_IS_AUTOMATABLE | CLAP_PARAM_IS_STEPPED};
 
     static constexpr uint64_t version_110 = 0x010100;
-    static constexpr uint64_t version_120a = 0x010201; // first chunk of 1.2.0; step sequencer
-    static constexpr uint64_t version_120b =
-        0x010202; // second chunk of 1.2.0; extended mode for source
+    // first chunk of 1.2.0; step sequencer
+    static constexpr uint64_t version_120a = 0x010201;
+    // second chunk of 1.2.0; extended mode for source
+    static constexpr uint64_t version_120b = 0x010202;
+    // third chunk of 1.2.0: super macros
+    static constexpr uint64_t version_120c = 0x010203;
 
     static md_t baseMd(uint64_t version = version_110) { return md_t().withVersion(version); }
     static md_t floatMd(uint64_t version = version_110)
@@ -109,6 +115,12 @@ struct Patch : pats::PatchBase<Patch, Param>
           mainPanMod()
     {
         MatrixIndex::initialize();
+        for (int i = 0; i < numMacros; ++i)
+        {
+            auto s = "Macro " + std::to_string(i + 1);
+            strncpy(macroNames[i].data(), s.c_str(), 63);
+            macroNames[i][63] = '\0';
+        }
         auto pushParams = [this](auto &from) { this->pushMultipleParams(from.params()); };
 
         pushParams(output);
@@ -153,7 +165,11 @@ struct Patch : pats::PatchBase<Patch, Param>
 
                       return a->meta.name < b->meta.name;
                   });
+
+        setupAdditionalState();
     }
+
+    void setupAdditionalState();
 
     struct LFOMixin
     {
@@ -169,20 +185,20 @@ struct Patch : pats::PatchBase<Patch, Param>
             Step
         };
 
-        LFOMixin(const std::string name, int id0, int stepid0 = -1)
-            : lfoRate(floatMd()
+        LFOMixin(const std::string name, int id0, int stepid0 = -1, uint64_t version = version_110)
+            : lfoRate(floatMd(version)
                           .asLfoRate(-7, 11)
                           .withName(name + " LFO Rate")
                           .withGroupName(name)
                           .withDefault(0)
                           .withID(id0 + 1)),
-              lfoDeform(floatMd()
+              lfoDeform(floatMd(version)
                             .asPercentBipolar()
                             .withName(name + " LFO Deform")
                             .withGroupName(name)
                             .withDefault(0)
                             .withID(id0 + 2)),
-              lfoShape(intMd()
+              lfoShape(intMd(version)
                            .withName(name + " LFO Shape")
                            .withGroupName(name)
                            .withRange(0, 7)
@@ -196,28 +212,28 @@ struct Patch : pats::PatchBase<Patch, Param>
                                                         {5, "Noise"},
                                                         {6, "S and H"},
                                                         {7, "Step"}})),
-              lfoActive(boolMd()
+              lfoActive(boolMd(version)
                             .withDefault(true)
                             .withID(id0 + 4)
                             .withName(name + " LFO Active")
                             .withGroupName(name)),
-              tempoSync(baseMd() // non-automatable
+              tempoSync(baseMd(version) // non-automatable
                             .asBool()
                             .withID(id0 + 5)
                             .withName(name + " Temposync")
                             .withGroupName(name)
                             .withDefault(false)),
-              lfoBipolar(boolMd()
+              lfoBipolar(boolMd(version)
                              .withDefault(true)
                              .withID(id0 + 6)
                              .withName(name + " Bipolar")
                              .withGroupName(name)),
-              lfoIsEnveloped(boolMd()
+              lfoIsEnveloped(boolMd(version)
                                  .withDefault(false)
                                  .withID(id0 + 7)
                                  .withName(name + " Is Enveloped")
                                  .withGroupName(name)),
-              lfoStartPhase(floatMd()
+              lfoStartPhase(floatMd(version)
                                 .withDefault(0)
                                 .withID(id0 + 8)
                                 .withName(name + " Start Phase")
@@ -292,62 +308,62 @@ struct Patch : pats::PatchBase<Patch, Param>
     {
 
         DAHDSRMixin(const std::string name, int id0, bool longAdsr, bool alwaysAdd = false,
-                    int id1 = -1)
-            : delay(floatEnvRateMd()
+                    int id1 = -1, uint64_t version = version_110)
+            : delay(floatEnvRateMd(version)
                         .withName(name + " Env Delay")
                         .withGroupName(name)
                         .withDefault(0.f)
                         .withID(id0 + 0)),
-              attack(floatEnvRateMd()
+              attack(floatEnvRateMd(version)
                          .withName(name + " Env Attack")
                          .withGroupName(name)
                          .withDefault(longAdsr ? 0.05 : 0.f)
                          .withID(id0 + 1)),
-              hold(floatEnvRateMd()
+              hold(floatEnvRateMd(version)
                        .withName(name + " Env Hold")
                        .withGroupName(name)
                        .withDefault(0.f)
                        .withID(id0 + 2)),
-              decay(floatEnvRateMd()
+              decay(floatEnvRateMd(version)
                         .withName(name + " Env Decay")
                         .withGroupName(name)
                         .withDefault(longAdsr ? 0.3 : 0.f)
                         .withID(id0 + 3)),
-              sustain(floatMd()
+              sustain(floatMd(version)
                           .asPercent()
                           .withName(name + " Env Sustain")
                           .withGroupName(name)
                           .withDefault(longAdsr ? 0.7f : 1.f)
                           .withID(id0 + 4)),
-              release(floatEnvRateMd()
+              release(floatEnvRateMd(version)
                           .withName(name + " Env Release")
                           .withGroupName(name)
                           .withDefault(longAdsr ? 0.4 : 1.f)
                           .withID(id0 + 5)),
-              envPower(boolMd()
+              envPower(boolMd(version)
                            .withName(name + " Env Power")
                            .withGroupName(name)
                            .withDefault(true)
                            .withID(id0 + 6)),
-              aShape(floatMd()
+              aShape(floatMd(version)
                          .asPercentBipolar()
                          .withName(name + " Attack Shape")
                          .withGroupName(name)
                          .withDefault(0)
                          .withID(id0 + 7)),
-              dShape(floatMd()
+              dShape(floatMd(version)
                          .asPercentBipolar()
                          .withName(name + " Decay Shape")
                          .withGroupName(name)
                          .withDefault(0)
                          .withID(id0 + 8)),
-              rShape(floatMd()
+              rShape(floatMd(version)
                          .asPercentBipolar()
                          .withName(name + " Release Shape")
                          .withGroupName(name)
                          .withDefault(0)
                          .withID(id0 + 9)),
-              triggerMode(intMd()
+              triggerMode(intMd(version)
                               .withRange(0, 3)
                               .withName(name + " Env Trigger Mode")
                               .withGroupName(name)
@@ -357,18 +373,18 @@ struct Patch : pats::PatchBase<Patch, Param>
                                                            {1, "Voice Start"},
                                                            {3, "Key Press"},
                                                            {2, "Patch Default"}})),
-              envIsMultiplcative(boolMd()
+              envIsMultiplcative(boolMd(version)
                                      .withName(name + " Env is Multiplicative")
                                      .withGroupName(name)
                                      .withDefault(!alwaysAdd)
                                      .withID(id0 + 11)
                                      .withUnorderedMapFormatting({{0, "Add"}, {1, "Scale"}})),
-              envIsOneShot(boolMd()
+              envIsOneShot(boolMd(version)
                                .withName(name + " Is OneShot")
                                .withGroupName(name)
                                .withDefault(false)
                                .withID(id0 + 12)),
-              envTriggersFromZero(boolMd()
+              envTriggersFromZero(boolMd(version)
                                       .withName(name + " Triggers from Zero")
                                       .withGroupName(name)
                                       .withDefault(false)
@@ -429,11 +445,11 @@ struct Patch : pats::PatchBase<Patch, Param>
 
     struct ModulationMixin
     {
-        ModulationMixin(const std::string name, int id0)
+        ModulationMixin(const std::string name, int id0, uint64_t version = version_110)
             : modsource(scpu::make_array_lambda<Param, numModsPer>(
-                  [id0, name](int i)
+                  [id0, name, version](int i)
                   {
-                      return baseMd()
+                      return baseMd(version)
                           .asInt()
                           .withRange(0, 8192)
                           .withID(id0 + 2 * i)
@@ -442,9 +458,9 @@ struct Patch : pats::PatchBase<Patch, Param>
                           .withDefault(0);
                   })),
               moddepth(scpu::make_array_lambda<Param, numModsPer>(
-                  [id0, name](int i)
+                  [id0, name, version](int i)
                   {
-                      return floatMd()
+                      return floatMd(version)
                           .asPercentBipolar()
                           .withID(id0 + 2 * i + 1)
                           .withName(name + " Mod Depth " + std::to_string(i))
@@ -1168,9 +1184,23 @@ struct Patch : pats::PatchBase<Patch, Param>
         }
     };
 
-    struct MacroNode
+    struct MacroNode : public DAHDSRMixin, public LFOMixin, public ModulationMixin
     {
         static constexpr uint32_t idBase{40000}, idStride{250};
+
+        enum TargetID : int32_t
+        {
+            SKIP = -1,
+            NONE = 0,
+            LEVEL = 10,
+            DEPTH_ATTEN = 20,
+        };
+
+        std::vector<std::pair<int32_t, std::string>> targetList{
+            {TargetID::NONE, "Off"},    {TargetID::SKIP, ""},
+            {TargetID::LEVEL, "Level"}, {TargetID::DEPTH_ATTEN, "Depth Atten"},
+            {TargetID::SKIP, ""},
+        };
 
         MacroNode(size_t idx)
             : level(floatMd()
@@ -1178,18 +1208,74 @@ struct Patch : pats::PatchBase<Patch, Param>
                         .withGroupName(name(idx))
                         .withName(name(idx) + " Level")
                         .withID(id(0, idx))
-                        .withDefault(0))
+                        .withDefault(0)
+                        .withFeature(isPrimaryMacroFeature)),
+              macroPower(boolMd(version_120c)
+                             .withGroupName(name(idx))
+                             .withName(name(idx) + " Power")
+                             .withID(id(1, idx))
+                             .withDefault(false)),
+              envDepth(floatMd(version_120c)
+                           .asPercentBipolar()
+                           .withGroupName(name(idx))
+                           .withName(name(idx) + " Env Depth")
+                           .withID(id(15, idx))
+                           .withDefault(0)),
+              lfoDepth(floatMd(version_120c)
+                           .asPercentBipolar()
+                           .withGroupName(name(idx))
+                           .withName(name(idx) + " LFO Depth")
+                           .withID(id(16, idx))
+                           .withDefault(1)),
+              DAHDSRMixin(name(idx), id(2, idx), false, false, id(20, idx), version_120c),
+              LFOMixin(name(idx), id(30, idx), id(65, idx), version_120c),
+              ModulationMixin(name(idx), id(50, idx), version_120c),
+              modtarget(scpu::make_array_lambda<Param, numModsPer>(
+                  [this, idx](int i)
+                  {
+                      return baseMd(version_120c)
+                          .withName(name(idx) + " Mod Target " + std::to_string(i))
+                          .withGroupName(name(idx))
+                          .withRange(0, 2000)
+                          .withDefault(TargetID::NONE)
+                          .withID(id(60 + i, idx));
+                  }))
         {
+            index = idx;
+            appendLFOTargetName(targetList);
+            appendDAHDSRTargetName(targetList);
         }
 
-        std::string name(int idx) const { return "Macro " + std::to_string(idx + 1); }
+        std::string name(int idx) const { return defaultGroupName(idx); }
         uint32_t id(int f, int idx) const { return idBase + idStride * idx + f; }
 
+        // Default group name. Used by name(idx) and by paramsInfo when building
+        // the "(Macro N)" suffix for the user-renamed level param.
+        static std::string defaultGroupName(int idx) { return "Macro " + std::to_string(idx + 1); }
+
+        int index{-1};
+        std::string name() const
+        {
+            if (index < 0)
+                throw std::runtime_error("Only call this post setup");
+            return name(index);
+        }
+
         Param level;
+        Param macroPower;
+        Param envDepth, lfoDepth;
+        std::array<Param, numModsPer> modtarget;
 
         std::vector<Param *> params()
         {
-            std::vector<Param *> res{&level};
+            std::vector<Param *> res{&level, &macroPower, &envDepth, &lfoDepth};
+            appendDAHDSRParams(res);
+            appendLFOParams(res);
+
+            for (int i = 0; i < numModsPer; ++i)
+                res.push_back(&modtarget[i]);
+            appendModulationParams(res);
+
             return res;
         }
     };
@@ -1615,6 +1701,7 @@ struct Patch : pats::PatchBase<Patch, Param>
     MainPanNode mainPanMod;
 
     char name[256]{"Init"};
+    std::array<std::array<char, 64>, numMacros> macroNames;
 
     float migrateParamValueFromVersion(Param *p, float value, uint32_t version);
     void migratePatchFromVersion(uint32_t version);

--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -745,6 +745,26 @@ void Synth::processUIQueue(const clap_output_events_t *outq)
             audioToUi.push({AudioToUIMsg::SET_PATCH_NAME, 0, 0, 0, patch.name});
         }
         break;
+        case MainToAudioMsg::SEND_MACRO_NAME:
+        {
+            auto idx = uiM->paramId;
+            if (idx < numMacros && uiM->uiManagedPointer)
+            {
+                auto &buf = patch.macroNames[idx];
+                std::fill(buf.begin(), buf.end(), 0);
+                strncpy(buf.data(), uiM->uiManagedPointer, buf.size() - 1);
+                AudioToUIMsg out{AudioToUIMsg::SET_MACRO_NAME};
+                out.paramId = idx;
+                out.patchNamePointer = buf.data();
+                audioToUi.push(out);
+
+                // Refresh host param info so the renamed macro picks up its display name.
+                AudioToUIMsg rescan{AudioToUIMsg::DO_PARAM_RESCAN};
+                rescan.paramId = CLAP_PARAM_RESCAN_INFO;
+                audioToUi.push(rescan);
+            }
+        }
+        break;
         case MainToAudioMsg::SEND_PATCH_IS_CLEAN:
         {
             patch.dirty = false;

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -339,9 +339,12 @@ struct Synth
             UPDATE_CPU_USAGE,
             SET_PATCH_NAME,
             SET_PATCH_DIRTY_STATE,
-            DO_PARAM_RESCAN,
+            DO_PARAM_RESCAN, // paramId optionally carries CLAP_PARAM_RESCAN_*
+                             // flags; 0 falls back to VALUES|TEXT
+
             SEND_SAMPLE_RATE,
-            SET_DAW_EXTRA_STATE
+            SET_DAW_EXTRA_STATE,
+            SET_MACRO_NAME // paramId = macro index, patchNamePointer = name buffer
         } action;
         uint32_t paramId{0};
         float value{0}, value2{0};
@@ -367,7 +370,8 @@ struct Synth
             SEND_PREP_FOR_STREAM,
             PANIC_STOP_VOICES,
             SET_DESIGN_MODE_RUN_ALL,
-            SET_DAW_EXTRA_STATE
+            SET_DAW_EXTRA_STATE,
+            SEND_MACRO_NAME // paramId = macro index, uiManagedPointer = name buffer
         } action;
         uint32_t paramId{0};
         float value{0};

--- a/src/synth/voice.cpp
+++ b/src/synth/voice.cpp
@@ -40,7 +40,9 @@ Voice::Voice(const Patch &p, MonoValues &mv)
           {
               return MatrixNodeFrom(p.matrixNodes[i], this->targetAtMatrix(i),
                                     this->sourceAtMatrix(i), mv, voiceValues);
-          }))
+          })),
+      macroNode(scpu::make_array_lambda<MacroVoiceNode, numMacros>(
+          [&p, this, &mv](auto i) { return MacroVoiceNode(p.macroNodes[i], mv, voiceValues); }))
 {
     std::fill(isKeytrack.begin(), isKeytrack.end(), true);
     std::fill(cmRatio.begin(), cmRatio.end(), 1.f);
@@ -53,6 +55,8 @@ void Voice::attack()
     voiceValues.velocityLag.snapTo(voiceValues.velocity);
     voiceValues.velocityLag.setRateInMilliseconds(10, monoValues.sr.sampleRate, 1.0 / blockSize);
 
+    for (auto &n : macroNode)
+        n.attack();
     out.attack();
     for (auto &n : mixerNode)
         n.attack();
@@ -98,6 +102,27 @@ void Voice::renderBlock()
 
     voiceValues.velocityLag.setTarget(voiceValues.velocity);
     voiceValues.velocityLag.process();
+
+    for (int m = 0; m < numMacros; ++m)
+    {
+        auto &mn = macroNode[m];
+        mn.macroPowerOn = mn.macroPowerV > 0.5f;
+        if (mn.macroPowerOn)
+        {
+            if (!mn.wasPowerOn)
+            {
+                mn.envAttack();
+                mn.lfoAttack();
+            }
+            mn.process();
+            voiceValues.macroOut[m] = mn.out;
+        }
+        else
+        {
+            voiceValues.macroOut[m] = *monoValues.macroPtr[m];
+        }
+        mn.wasPowerOn = mn.macroPowerOn;
+    }
 
     for (int i = 0; i < numOps; ++i)
     {
@@ -154,6 +179,11 @@ void Voice::retriggerAllEnvelopesForKeyPress()
                     (tm == TriggerMode::PATCH_DEFAULT && dtm == TriggerMode::KEY_PRESS));
         return res;
     };
+    for (auto &m : macroNode)
+        if (m.macroPowerOn)
+            if (mtm(m.triggerMode))
+                m.envAttack();
+
     for (auto &s : src)
         if (s.active)
             if (mtm(s.triggerMode))
@@ -201,6 +231,11 @@ void Voice::retriggerAllEnvelopesForReGate()
         return (tm != TriggerMode::NEW_VOICE);
     };
 
+    for (auto &m : macroNode)
+        if (m.macroPowerOn)
+            if (mtm(m.triggerMode))
+                m.envAttack();
+
     for (auto &s : src)
         if (s.active)
             if (mtm(s.triggerMode))
@@ -244,6 +279,9 @@ void Voice::cleanup()
     voiceValues.dPorta = 0;
     voiceValues.dPortaFrac = 0;
     voiceValues.mpeBendInSemis = 0;
+
+    for (auto &m : macroNode)
+        m.envCleanup();
 
     for (auto &s : src)
     {

--- a/src/synth/voice.h
+++ b/src/synth/voice.h
@@ -19,6 +19,7 @@
 #include <sst/basic-blocks/tables/EqualTuningProvider.h>
 #include "dsp/op_source.h"
 #include "dsp/matrix_node.h"
+#include "dsp/macro_node.h"
 #include "synth/mono_values.h"
 #include "synth/voice_values.h"
 
@@ -60,6 +61,7 @@ struct Voice
     void restartPortaTo(float sourceKey, uint16_t newKey, float log2Seconds, float portaFrac);
 
     std::array<MixerNode, numOps> mixerNode;
+    std::array<MacroVoiceNode, numMacros> macroNode;
     static constexpr int32_t fadeOverBlocks{32};
     float dFade{1.0 / (blockSize * fadeOverBlocks)};
     int32_t fadeBlocks{-1};

--- a/src/synth/voice_values.h
+++ b/src/synth/voice_values.h
@@ -16,9 +16,11 @@
 #ifndef BACONPAUL_SIX_SINES_SYNTH_VOICE_VALUES_H
 #define BACONPAUL_SIX_SINES_SYNTH_VOICE_VALUES_H
 
+#include <array>
 #include <sst/basic-blocks/tables/EqualTuningProvider.h>
 #include <sst/basic-blocks/tables/TwoToTheXProvider.h>
 #include "sst/basic-blocks/dsp/Lag.h"
+#include "configuration.h"
 
 struct MTSClient;
 
@@ -64,6 +66,8 @@ struct VoiceValues
     bool phaseRandom{false}, rephaseOnRetrigger{false};
 
     sst::basic_blocks::dsp::OnePoleLag<float, false> velocityLag;
+
+    std::array<float, numMacros> macroOut{};
 
   private:
     bool gatedV{false};

--- a/src/ui/dahdsr-components.h
+++ b/src/ui/dahdsr-components.h
@@ -65,9 +65,9 @@ template <typename Comp, typename PatchPart> struct DAHDSRComponents
         c->addAndMakeVisible(*shapes[1]);
         c->addAndMakeVisible(*shapes[2]);
 
-        titleLab = std::make_unique<jcmp::RuledLabel>();
-        titleLab->setText("Envelope");
-        asComp()->addAndMakeVisible(*titleLab);
+        envTitleLab = std::make_unique<jcmp::RuledLabel>();
+        envTitleLab->setText("Envelope");
+        asComp()->addAndMakeVisible(*envTitleLab);
 
         triggerButton = std::make_unique<jcmp::TextPushButton>();
         triggerButton->setOnCallback(
@@ -96,7 +96,7 @@ template <typename Comp, typename PatchPart> struct DAHDSRComponents
 
     juce::Rectangle<int> layoutDAHDSRAt(int x, int y)
     {
-        if (!titleLab || !slider[0])
+        if (!envTitleLab || !slider[0])
             return {};
 
         namespace jlo = sst::jucegui::layouts;
@@ -104,7 +104,7 @@ template <typename Comp, typename PatchPart> struct DAHDSRComponents
         auto lo =
             jlo::VList().at(x, y).withHeight(180 - uicMargin).withWidth(nels * uicSliderWidth);
 
-        lo.add(titleLabelLayout(titleLab));
+        lo.add(titleLabelLayout(envTitleLab));
         auto sliders = jlo::HList().expandToFill();
 
         for (int i = 0; i < nels; ++i)
@@ -139,7 +139,7 @@ template <typename Comp, typename PatchPart> struct DAHDSRComponents
     std::array<std::unique_ptr<jcmp::Knob>, nShape> shapes;
     std::array<std::unique_ptr<PatchContinuous>, nShape> shapesD;
     std::array<std::unique_ptr<jcmp::Label>, nels> lab;
-    std::unique_ptr<jcmp::RuledLabel> titleLab;
+    std::unique_ptr<jcmp::RuledLabel> envTitleLab;
 
     std::unique_ptr<jcmp::TextPushButton> triggerButton;
     void setTriggerLabel()

--- a/src/ui/lfo-components.h
+++ b/src/ui/lfo-components.h
@@ -240,9 +240,9 @@ template <typename Comp, typename Patch> struct LFOComponents
         createComponent(e, *c, v.lfoShape, shape, shapeD);
         c->addAndMakeVisible(*shape);
 
-        titleLab = std::make_unique<jcmp::RuledLabel>();
-        titleLab->setText("LFO");
-        c->addAndMakeVisible(*titleLab);
+        lfoTitleLab = std::make_unique<jcmp::RuledLabel>();
+        lfoTitleLab->setText("LFO");
+        c->addAndMakeVisible(*lfoTitleLab);
 
         createComponent(e, *c, v.tempoSync, tempoSync, tempoSyncD);
         tempoSync->setDrawMode(jcmp::ToggleButton::DrawMode::LABELED);
@@ -316,7 +316,7 @@ template <typename Comp, typename Patch> struct LFOComponents
 
     juce::Rectangle<int> layoutLFOAt(int x, int y, int width = -1)
     {
-        if (!titleLab)
+        if (!lfoTitleLab)
             return {};
 
         namespace jlo = sst::jucegui::layouts;
@@ -326,7 +326,7 @@ template <typename Comp, typename Patch> struct LFOComponents
 
         auto lo = jlo::VList().at(x, y).withHeight(h).withWidth(w);
 
-        lo.add(titleLabelLayout(titleLab));
+        lo.add(titleLabelLayout(lfoTitleLab));
 
         auto columns = jlo::HList().expandToFill().withAutoGap(uicMargin);
 
@@ -368,7 +368,7 @@ template <typename Comp, typename Patch> struct LFOComponents
 
     std::unique_ptr<jcmp::MultiSwitch> shape;
     std::unique_ptr<PatchDiscrete> shapeD;
-    std::unique_ptr<jcmp::RuledLabel> titleLab;
+    std::unique_ptr<jcmp::RuledLabel> lfoTitleLab;
 
     std::unique_ptr<jcmp::ToggleButton> tempoSync;
     std::unique_ptr<PatchDiscrete> tempoSyncD;

--- a/src/ui/macro-panel.cpp
+++ b/src/ui/macro-panel.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "macro-panel.h"
+#include "macro-sub-panel.h"
 #include "six-sines-editor.h"
 #include "ui-constants.h"
 #include "knob-highlight.h"
@@ -35,16 +36,16 @@ MacroPanel::MacroPanel(SixSinesEditor &e) : jcmp::NamedPanel("Macros"), HasEdito
         labels[i]->setText("Macro " + std::to_string(i + 1));
         addAndMakeVisible(*labels[i]);
 
-        powerOnState[i] = true;
-        powerD[i] = std::make_unique<
-            sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::ToggleButton, bool>>(
-            powerOnState[i]);
-        power[i] = powerD[i]->widget.get();
+        createComponent(editor, *this, mn[i].macroPower, power[i], powerD[i], i);
         power[i]->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::GLYPH);
         power[i]->setGlyph(sst::jucegui::components::GlyphPainter::POWER);
         addAndMakeVisible(*power[i]);
     }
+
+    highlight = std::make_unique<KnobHighlight>(editor);
+    addChildComponent(*highlight);
 }
+
 MacroPanel::~MacroPanel() = default;
 
 void MacroPanel::resized()
@@ -59,6 +60,47 @@ void MacroPanel::resized()
     }
 }
 
-void MacroPanel::beginEdit(size_t idx) {}
+juce::Rectangle<int> MacroPanel::rectangleFor(int idx)
+{
+    auto b = getContentArea().reduced(uicMargin, 0);
+    return juce::Rectangle<int>(b.getX() + idx * (uicPowerKnobWidth + uicMargin), b.getY(),
+                                uicPowerKnobWidth + 2, uicLabeledKnobHeight);
+}
+
+void MacroPanel::mouseDown(const juce::MouseEvent &e)
+{
+    if (e.mods.isPopupMenu())
+    {
+        editor.showNavigationMenu();
+        return;
+    }
+    for (int i = 0; i < numMacros; ++i)
+    {
+        if (rectangleFor(i).contains(e.position.toInt()))
+        {
+            beginEdit(i);
+        }
+    }
+}
+
+void MacroPanel::refreshLabel(size_t idx)
+{
+    if (idx >= numMacros || !labels[idx])
+        return;
+    labels[idx]->setText(displayShortName(editor, idx));
+    labels[idx]->repaint();
+}
+
+void MacroPanel::beginEdit(size_t idx)
+{
+    editor.hideAllSubPanels();
+    editor.activateHamburger(true);
+    editor.macroSubPanel->setSelectedIndex(idx);
+    editor.macroSubPanel->setVisible(true);
+    editor.singlePanel->setName(editor.macroSubPanel->displayName());
+    highlight->setBounds(rectangleFor(idx));
+    highlight->setVisible(true);
+    highlight->toBack();
+}
 
 } // namespace baconpaul::six_sines::ui

--- a/src/ui/macro-panel.h
+++ b/src/ui/macro-panel.h
@@ -19,7 +19,6 @@
 #include <sst/jucegui/components/Knob.h>
 #include <sst/jucegui/components/Label.h>
 #include <sst/jucegui/components/ToggleButton.h>
-#include <sst/jucegui/component-adapters/DiscreteToReference.h>
 #include <sst/jucegui/data/Continuous.h>
 #include "six-sines-editor.h"
 #include "patch-data-bindings.h"
@@ -38,17 +37,41 @@ struct MacroPanel : jcmp::NamedPanel, HasEditor
 
     void beginEdit(size_t idx);
 
+    void refreshLabel(size_t idx);
+
+    // Single source of truth for macro display names. Short = knob label,
+    // Full = sub-panel title. Both fall back to "Macro N" when unrenamed.
+    static std::string displayShortName(const SixSinesEditor &editor, size_t idx)
+    {
+        auto &buf = editor.patchCopy.macroNames[idx];
+        std::string nm(buf.data());
+        auto def = "Macro " + std::to_string(idx + 1);
+        return (nm.empty() || nm == def) ? def : nm;
+    }
+    static std::string displayName(const SixSinesEditor &editor, size_t idx)
+    {
+        auto &buf = editor.patchCopy.macroNames[idx];
+        std::string nm(buf.data());
+        auto def = "Macro " + std::to_string(idx + 1);
+        return (nm.empty() || nm == def) ? def : (nm + " (" + def + ")");
+    }
+
+    void mouseDown(const juce::MouseEvent &e) override;
+    juce::Rectangle<int> rectangleFor(int idx);
+
+    std::unique_ptr<juce::Component> highlight;
+    void clearHighlight()
+    {
+        if (highlight)
+            highlight->setVisible(false);
+    }
+
     std::array<std::unique_ptr<jcmp::Knob>, numMacros> knobs;
     std::array<std::unique_ptr<PatchContinuous>, numMacros> knobsData;
     std::array<std::unique_ptr<jcmp::Label>, numMacros> labels;
 
-    // Placeholder power toggles — not yet wired to any patch data.
-    std::array<bool, numMacros> powerOnState{};
-    std::array<std::unique_ptr<sst::jucegui::component_adapters::DiscreteToValueReference<
-                   jcmp::ToggleButton, bool>>,
-               numMacros>
-        powerD;
-    std::array<jcmp::ToggleButton *, numOps> power{};
+    std::array<std::unique_ptr<jcmp::ToggleButton>, numMacros> power;
+    std::array<std::unique_ptr<PatchDiscrete>, numMacros> powerD;
 };
 } // namespace baconpaul::six_sines::ui
-#endif // Macro_PANE_H
+#endif // BACONPAUL_SIX_SINES_UI_MACRO_PANEL_H

--- a/src/ui/macro-sub-panel.cpp
+++ b/src/ui/macro-sub-panel.cpp
@@ -1,0 +1,394 @@
+/*
+ * Six Sines
+ *
+ * A synth with audio rate modulation.
+ *
+ * Copyright 2024-2025, Paul Walker and Various authors, as described in the github
+ * transaction log.
+ *
+ * This source repo is released under the MIT license, but has
+ * GPL3 dependencies, as such the combined work will be
+ * released under GPL3.
+ *
+ * The source code and license are at https://github.com/baconpaul/six-sines
+ */
+
+#include "macro-sub-panel.h"
+#include "macro-panel.h"
+#include "main-panel.h"
+#include "matrix-panel.h"
+#include "mixer-panel.h"
+#include "source-panel.h"
+#include "ui-constants.h"
+#include <cstring>
+#include <sst/jucegui/layouts/ListLayout.h>
+
+namespace baconpaul::six_sines::ui
+{
+
+MacroSubPanel::MacroSubPanel(SixSinesEditor &e) : HasEditor(e)
+{
+    nameEditor = std::make_unique<jcmp::TextEditor>();
+    nameEditor->setMultiLine(false);
+    nameEditor->setReturnKeyStartsNewLine(false);
+    nameEditor->setJustification(juce::Justification::centredTop);
+    nameEditor->onReturnKey = [this]() { commitName(); };
+    nameEditor->onFocusLost = [this]() { commitName(); };
+    addAndMakeVisible(*nameEditor);
+
+    nameTitle = std::make_unique<jcmp::RuledLabel>();
+    nameTitle->setText("Name");
+    addAndMakeVisible(*nameTitle);
+
+    usedByTitle = std::make_unique<jcmp::RuledLabel>();
+    usedByTitle->setText("Used By");
+    addAndMakeVisible(*usedByTitle);
+
+    setSelectedIndex(0);
+}
+
+MacroSubPanel::~MacroSubPanel() {}
+
+void MacroSubPanel::setSelectedIndex(size_t i)
+{
+    index = i;
+
+    removeAllChildren();
+
+    auto &mn = editor.patchCopy.macroNodes[i];
+
+    setupDAHDSR(editor, mn);
+    setupLFO(editor, mn);
+    setupModulation(editor, mn);
+
+    // Excludes self/higher-indexed macros, then falls through to shared.
+    sourceFilter = [this](int sid) -> SourceFilterResult
+    {
+        using S = ModMatrixConfig::Source;
+        auto isAmp = sid >= S::MACRO_0 && sid < S::MACRO_0 + (int)numMacros;
+        auto isMod = sid >= S::MACRO_MOD_0 && sid < S::MACRO_MOD_0 + (int)numMacros;
+        if (isAmp && (sid - (int)S::MACRO_0) >= (int)index)
+            return SourceFilterResult::Exclude;
+        if (isMod && (sid - (int)S::MACRO_MOD_0) >= (int)index)
+            return SourceFilterResult::Exclude;
+        return sharedSourceFilter(sid);
+    };
+
+    addAndMakeVisible(*nameTitle);
+    addAndMakeVisible(*nameEditor);
+    addAndMakeVisible(*usedByTitle);
+
+    // Env-/LFO-→ row above the Name section
+    envSecLab = std::make_unique<jcmp::RuledLabel>();
+    envSecLab->setText(std::string() + "Env" + u8"\U00002192");
+    addAndMakeVisible(*envSecLab);
+
+    lfoSecLab = std::make_unique<jcmp::RuledLabel>();
+    lfoSecLab->setText(std::string() + "LFO" + u8"\U00002192");
+    addAndMakeVisible(*lfoSecLab);
+
+    createRescaledComponent(editor, *this, mn.envDepth, envDepthKnob, envDepthDA);
+    addAndMakeVisible(*envDepthKnob);
+    envDepthLab = std::make_unique<jcmp::Label>();
+    envDepthLab->setText("Depth");
+    addAndMakeVisible(*envDepthLab);
+
+    createRescaledComponent(editor, *this, mn.lfoDepth, lfoDepthKnob, lfoDepthDA);
+    addAndMakeVisible(*lfoDepthKnob);
+    lfoDepthLab = std::make_unique<jcmp::Label>();
+    lfoDepthLab->setText("Depth");
+    addAndMakeVisible(*lfoDepthLab);
+
+    createComponent(editor, *this, mn.envIsMultiplcative, envMul, envMulD);
+    addAndMakeVisible(*envMul);
+
+    auto refreshEnabled = [w = juce::Component::SafePointer(this)]()
+    {
+        if (w)
+            w->setEnabledState();
+    };
+    editor.componentRefreshByID[mn.envIsMultiplcative.meta.id] = refreshEnabled;
+    envMulD->onGuiSetValue = refreshEnabled;
+
+    auto &nameBuf = editor.patchCopy.macroNames[i];
+    nameEditor->setText(juce::String(nameBuf.data()), juce::dontSendNotification);
+
+    setEnabledState();
+    refreshUsedByList();
+
+    resized();
+    repaint();
+}
+
+void MacroSubPanel::resized()
+{
+    auto p = getLocalBounds().reduced(uicMargin, 0);
+
+    auto pn = layoutDAHDSRAt(p.getX(), p.getY());
+    auto r = layoutLFOAt(pn.getX() + uicMargin, p.getY());
+    layoutModulation(p);
+
+    // Env-→ row spans two columns (depth knob + add/scale switch); LFO-→ stays one column.
+    auto depY = std::max(pn.getBottom(), r.getBottom()) + uicMargin;
+    auto envColW = 2 * uicSubPanelColumnWidth + uicMargin;
+    auto lfoColW = uicSubPanelColumnWidth;
+    auto envX = p.getX();
+    auto lfoX = envX + envColW + 2 * uicMargin;
+
+    envSecLab->setBounds(envX, depY, envColW, uicTitleLabelInnerBox);
+    lfoSecLab->setBounds(lfoX, depY, lfoColW, uicTitleLabelInnerBox);
+
+    auto bodyY = depY + uicTitleLabelInnerBox + uicMargin;
+
+    auto envDepthKnobX = envX + (int)(uicSubPanelColumnWidth - uicKnobSize) / 2;
+    envDepthKnob->setBounds(envDepthKnobX, bodyY, uicKnobSize, uicKnobSize);
+    envDepthLab->setBounds(envX, bodyY + uicKnobSize + uicLabelGap, uicSubPanelColumnWidth,
+                           uicLabelHeight);
+
+    // Vertically center the add/scale switch against the labeled knob height.
+    auto switchH = 2 * uicLabelHeight + uicMargin;
+    auto switchX = envX + uicSubPanelColumnWidth + uicMargin;
+    auto switchY = bodyY + ((int)uicLabeledKnobHeight - (int)switchH) / 2;
+    envMul->setBounds(switchX, switchY, uicSubPanelColumnWidth, switchH);
+
+    auto lfoDepthKnobX = lfoX + (int)(uicSubPanelColumnWidth - uicKnobSize) / 2;
+    lfoDepthKnob->setBounds(lfoDepthKnobX, bodyY, uicKnobSize, uicKnobSize);
+    lfoDepthLab->setBounds(lfoX, bodyY + uicKnobSize + uicLabelGap, lfoColW, uicLabelHeight);
+
+    auto nameY = bodyY + uicLabeledKnobHeight + uicMargin;
+    nameTitle->setBounds(p.getX(), nameY, p.getWidth(), uicTitleLabelInnerBox);
+    auto edInset = 60;
+    nameEditor->setBounds(p.getX() + edInset, nameY + uicTitleLabelInnerBox + uicMargin,
+                          p.getWidth() - 2 * edInset, 24);
+
+    auto usedByY = nameY + uicTitleLabelInnerBox + uicMargin + 24 + uicMargin;
+    usedByTitle->setBounds(p.getX(), usedByY, p.getWidth(), uicTitleLabelInnerBox);
+    auto rowY = usedByY + uicTitleLabelInnerBox + uicMargin;
+
+    if (usedByEmptyState && !usedByRows.empty() && usedByRows.front().nodeLabel)
+    {
+        usedByRows.front().nodeLabel->setBounds(p.getX(), rowY, p.getWidth(), uicLabelHeight);
+        return;
+    }
+
+    constexpr int btnW = uicLabelHeight;
+    constexpr int variantW = 40;
+    constexpr int nodeW = 140;
+    auto gap = uicMargin;
+    for (auto &row : usedByRows)
+    {
+        auto x = p.getX();
+        if (row.jumpButton)
+            row.jumpButton->setBounds(x, rowY, btnW, uicLabelHeight);
+        x += btnW + gap;
+        if (row.nodeLabel)
+            row.nodeLabel->setBounds(x, rowY, nodeW, uicLabelHeight);
+        x += nodeW + gap;
+        if (row.variantLabel)
+            row.variantLabel->setBounds(x, rowY, variantW, uicLabelHeight);
+        x += variantW + gap;
+        if (row.targetLabel)
+            row.targetLabel->setBounds(x, rowY, p.getRight() - x, uicLabelHeight);
+        rowY += uicLabelHeight + uicLabelGap;
+    }
+}
+
+void MacroSubPanel::setEnabledState()
+{
+    if (!patchPartPtr)
+        return;
+    auto on = patchPartPtr->macroPower.value > 0.5;
+
+    // Envelope widgets
+    for (auto &s : slider)
+        if (s)
+            s->setEnabled(on);
+    for (auto &l : lab)
+        if (l)
+            l->setEnabled(on);
+    for (auto &sh : shapes)
+        if (sh)
+            sh->setEnabled(on);
+    if (triggerButton)
+        triggerButton->setEnabled(on);
+    if (envTitleLab)
+        envTitleLab->setEnabled(on);
+    if (lfoTitleLab)
+        lfoTitleLab->setEnabled(on);
+
+    // LFO widgets
+    lfoSetEnabledState(on);
+
+    // Modulation widgets
+    for (auto &sm : sourceMenu)
+        if (sm)
+            sm->setEnabled(on);
+    for (auto &tm : targetMenu)
+        if (tm)
+            tm->setEnabled(on);
+    for (auto &ds : depthSlider)
+        if (ds)
+            ds->setEnabled(on);
+    if (modTitleLab)
+        modTitleLab->setEnabled(on);
+
+    // Env-/LFO-→ widgets. envDepth only matters in Add mode (envIsMul=0).
+    auto inAddMode = envMulD && envMulD->getValue() < 0.5;
+    if (envSecLab)
+        envSecLab->setEnabled(on);
+    if (lfoSecLab)
+        lfoSecLab->setEnabled(on);
+    if (envDepthKnob)
+        envDepthKnob->setEnabled(on && inAddMode);
+    if (envDepthLab)
+        envDepthLab->setEnabled(on && inAddMode);
+    if (envMul)
+        envMul->setEnabled(on);
+    if (lfoDepthKnob)
+        lfoDepthKnob->setEnabled(on);
+    if (lfoDepthLab)
+        lfoDepthLab->setEnabled(on);
+
+    // nameEditor, powerToggle stay enabled regardless
+    if (nameEditor)
+        nameEditor->setEnabled(true);
+    repaint();
+}
+
+void MacroSubPanel::refreshNameFromPatch()
+{
+    if (!nameEditor)
+        return;
+    auto &buf = editor.patchCopy.macroNames[index];
+    nameEditor->setText(juce::String(buf.data()), juce::dontSendNotification);
+    if (editor.singlePanel)
+        editor.singlePanel->setName(displayName());
+}
+
+void MacroSubPanel::refreshUsedByList()
+{
+    usedByRows.clear();
+    auto &uses = editor.macroUsageCache[index];
+    if (uses.empty())
+    {
+        UsedByRow row;
+        row.nodeLabel = std::make_unique<jcmp::Label>();
+        row.nodeLabel->setText("(macro unused)");
+        addAndMakeVisible(*row.nodeLabel);
+        usedByRows.push_back(std::move(row));
+        usedByEmptyState = true;
+    }
+    else
+    {
+        usedByEmptyState = false;
+        for (auto &u : uses)
+        {
+            UsedByRow row;
+            row.jumpButton =
+                std::make_unique<jcmp::GlyphButton>(jcmp::GlyphPainter::GlyphType::JOG_RIGHT);
+            // Copy: the cache rebuilds on routing changes, invalidating refs into it.
+            auto refCopy = u;
+            row.jumpButton->setOnCallback(
+                [w = juce::Component::SafePointer(this), refCopy]()
+                {
+                    if (w)
+                        w->jumpTo(refCopy);
+                });
+            addAndMakeVisible(*row.jumpButton);
+
+            row.nodeLabel = std::make_unique<jcmp::Label>();
+            row.nodeLabel->setText(u.nodeLabel);
+            addAndMakeVisible(*row.nodeLabel);
+
+            row.variantLabel = std::make_unique<jcmp::Label>();
+            row.variantLabel->setText(u.modulated ? "mod" : "amp");
+            addAndMakeVisible(*row.variantLabel);
+
+            row.targetLabel = std::make_unique<jcmp::Label>();
+            row.targetLabel->setText(u.targetName);
+            addAndMakeVisible(*row.targetLabel);
+
+            usedByRows.push_back(std::move(row));
+        }
+    }
+    resized();
+}
+
+void MacroSubPanel::jumpTo(const MacroUsedRef &ref)
+{
+    using K = MacroUsedRef::NodeKind;
+    switch (ref.kind)
+    {
+    case K::SourceOp:
+        if (editor.sourcePanel)
+            editor.sourcePanel->beginEdit(ref.index);
+        break;
+    case K::SelfOp:
+        if (editor.matrixPanel)
+            editor.matrixPanel->beginEdit(ref.index, true);
+        break;
+    case K::MixerOp:
+        if (editor.mixerPanel)
+            editor.mixerPanel->beginEdit(ref.index);
+        break;
+    case K::Matrix:
+        if (editor.matrixPanel)
+            editor.matrixPanel->beginEdit(ref.index, false);
+        break;
+    case K::Macro:
+        if (editor.macroPanel)
+            editor.macroPanel->beginEdit(ref.index);
+        break;
+    case K::MainOutput:
+        if (editor.mainPanel)
+            editor.mainPanel->beginEdit(0);
+        break;
+    case K::MainPan:
+        if (editor.mainPanel)
+            editor.mainPanel->beginEdit(1);
+        break;
+    case K::FineTune:
+        if (editor.mainPanel)
+            editor.mainPanel->beginEdit(2);
+        break;
+    }
+}
+
+std::string MacroSubPanel::displayShortName() const
+{
+    return MacroPanel::displayShortName(editor, index);
+}
+
+std::string MacroSubPanel::displayName() const { return MacroPanel::displayName(editor, index); }
+
+void MacroSubPanel::commitName()
+{
+    auto txt = nameEditor->getText().toStdString();
+    auto &buf = editor.patchCopy.macroNames[index];
+
+    // No-op on focus-enter/exit without an edit; only push on real changes.
+    if (std::strncmp(buf.data(), txt.c_str(), buf.size()) == 0)
+        return;
+
+    std::fill(buf.begin(), buf.end(), 0);
+    auto n = std::min(txt.size(), buf.size() - 1);
+    std::memcpy(buf.data(), txt.data(), n);
+
+    Synth::MainToAudioMsg msg{Synth::MainToAudioMsg::SEND_MACRO_NAME};
+    msg.paramId = static_cast<uint32_t>(index);
+    msg.uiManagedPointer = buf.data();
+    editor.mainToAudio.push(msg);
+
+    if (editor.macroPanel && index < editor.macroPanel->labels.size() &&
+        editor.macroPanel->labels[index])
+    {
+        editor.macroPanel->labels[index]->setText(displayShortName());
+        editor.macroPanel->labels[index]->repaint();
+    }
+    if (editor.singlePanel)
+        editor.singlePanel->setName(displayName());
+}
+
+IMPLEMENTS_CLIPBOARD_SUPPORT(MacroSubPanel, macroNodes[index], Clipboard::ClipboardType::NONE)
+
+} // namespace baconpaul::six_sines::ui

--- a/src/ui/macro-sub-panel.h
+++ b/src/ui/macro-sub-panel.h
@@ -1,0 +1,94 @@
+/*
+ * Six Sines
+ *
+ * A synth with audio rate modulation.
+ *
+ * Copyright 2024-2025, Paul Walker and Various authors, as described in the github
+ * transaction log.
+ *
+ * This source repo is released under the MIT license, but has
+ * GPL3 dependencies, as such the combined work will be
+ * released under GPL3.
+ *
+ * The source code and license are at https://github.com/baconpaul/six-sines
+ */
+
+#ifndef BACONPAUL_SIX_SINES_UI_MACRO_SUB_PANEL_H
+#define BACONPAUL_SIX_SINES_UI_MACRO_SUB_PANEL_H
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <sst/jucegui/components/TextEditor.h>
+#include <sst/jucegui/components/GlyphButton.h>
+#include "six-sines-editor.h"
+#include "dahdsr-components.h"
+#include "lfo-components.h"
+#include "modulation-components.h"
+#include "clipboard.h"
+#include "synth/macro_usage.h"
+
+namespace baconpaul::six_sines::ui
+{
+struct MacroSubPanel : juce::Component,
+                       HasEditor,
+                       DAHDSRComponents<MacroSubPanel, Patch::MacroNode>,
+                       LFOComponents<MacroSubPanel, Patch::MacroNode>,
+                       ModulationComponents<MacroSubPanel, Patch::MacroNode>,
+                       SupportsClipboard
+{
+    MacroSubPanel(SixSinesEditor &);
+    ~MacroSubPanel();
+
+    size_t index{0};
+    void setSelectedIndex(size_t i);
+
+    void resized() override;
+    void beginEdit() {}
+
+    std::unique_ptr<jcmp::TextEditor> nameEditor;
+
+    std::unique_ptr<jcmp::RuledLabel> nameTitle;
+    std::unique_ptr<jcmp::RuledLabel> usedByTitle;
+
+    // One row per consumer. usedByEmptyState=true uses a single row with only
+    // nodeLabel populated ("(macro unused)").
+    struct UsedByRow
+    {
+        std::unique_ptr<jcmp::GlyphButton> jumpButton;
+        std::unique_ptr<jcmp::Label> nodeLabel;
+        std::unique_ptr<jcmp::Label> variantLabel;
+        std::unique_ptr<jcmp::Label> targetLabel;
+    };
+    std::vector<UsedByRow> usedByRows;
+    bool usedByEmptyState{false};
+
+    void jumpTo(const MacroUsedRef &ref);
+
+    // Env-/LFO-→ row above the Name section.
+    std::unique_ptr<jcmp::RuledLabel> envSecLab, lfoSecLab;
+    std::unique_ptr<jcmp::Knob> envDepthKnob, lfoDepthKnob;
+    std::unique_ptr<PatchContinuous::cubic_t> envDepthDA, lfoDepthDA;
+    std::unique_ptr<jcmp::Label> envDepthLab, lfoDepthLab;
+    std::unique_ptr<jcmp::MultiSwitch> envMul;
+    std::unique_ptr<PatchDiscrete> envMulD;
+
+    void setEnabledState();
+    void refreshUsedByList();
+
+    // Persist the name editor's text into patchCopy, push to audio thread, and
+    // refresh the dependent UI (MacroPanel label + singlePanel title).
+    void commitName();
+
+    // Re-reads patchCopy.macroNames[index] into nameEditor and refreshes the
+    // singlePanel title. Called when the audio thread tells us the name
+    // changed (patch load, etc.) and this sub-panel is the visible one.
+    void refreshNameFromPatch();
+
+    // "Foo" if user-named, else "Macro N". Used on the MacroPanel knob label.
+    std::string displayShortName() const;
+    // "Foo (Macro N)" if user-named, else "Macro N". Used on the singlePanel title.
+    std::string displayName() const;
+
+    HAS_CLIPBOARD_SUPPORT;
+};
+} // namespace baconpaul::six_sines::ui
+#endif // BACONPAUL_SIX_SINES_UI_MACRO_SUB_PANEL_H

--- a/src/ui/modulation-components.h
+++ b/src/ui/modulation-components.h
@@ -26,6 +26,14 @@
 namespace baconpaul::six_sines::ui
 {
 namespace jcmp = sst::jucegui::components;
+
+enum class SourceFilterResult
+{
+    Include,  // show normally
+    Exclude,  // omit from menu entirely
+    Disabled, // show greyed and unselectable
+};
+
 template <typename Comp, typename Patch> struct ModulationComponents
 {
     Comp *asComp() { return static_cast<Comp *>(this); }
@@ -191,6 +199,8 @@ template <typename Comp, typename Patch> struct ModulationComponents
                                   return;
                               w->editor.setAndSendParamValue(w->patchPtr->modtarget[index], si);
                               w->resetTargetLabel(index);
+                              if (w->editor.onModulationRoutingChanged)
+                                  w->editor.onModulationRoutingChanged();
                           });
             }
         }
@@ -224,6 +234,8 @@ template <typename Comp, typename Patch> struct ModulationComponents
                     SXSNLOG("ERROR: GENSET with sCopy=2048 " << lidx);
                 w->editor.setAndSendParamValue(w->patchPtr->modsource[lidx], sCopy);
                 w->resetSourceLabel(lidx);
+                if (w->editor.onModulationRoutingChanged)
+                    w->editor.onModulationRoutingChanged();
             };
         };
 
@@ -235,11 +247,18 @@ template <typename Comp, typename Patch> struct ModulationComponents
             if (debugLevel > 0)
                 dname += " (" + std::to_string(id) + ")";
 
+            auto filt = sourceFilter(static_cast<int>(id));
+            if (filt == SourceFilterResult::Exclude)
+                continue;
+            auto enabled = (filt != SourceFilterResult::Disabled);
+
             auto ticked = (static_cast<int32_t>(id) == currentSource);
 
             if (so.group.empty())
             {
-                p.addItem(dname, true, ticked, genSet(id));
+                if (so.addSeparatorBefore)
+                    p.addSeparator();
+                p.addItem(dname, enabled, ticked, genSet(id));
             }
             else
             {
@@ -249,7 +268,9 @@ template <typename Comp, typename Patch> struct ModulationComponents
                     s = juce::PopupMenu();
                 }
                 currCat = so.group;
-                s.addItem(dname, true, ticked, genSet(id));
+                if (so.addSeparatorBefore)
+                    s.addSeparator();
+                s.addItem(dname, enabled, ticked, genSet(id));
             }
         }
         if (s.getNumItems() > 0)
@@ -268,8 +289,26 @@ template <typename Comp, typename Patch> struct ModulationComponents
     std::array<std::unique_ptr<PatchContinuous>, numModsPer> depthSliderD;
 
     // Override per-panel to grey out targets that don't apply to the current node state
-    // (e.g. EXTEND_M only available in PHASE_REMAP). Sources are always enabled.
+    // (e.g. EXTEND_M only available in PHASE_REMAP).
     std::function<bool(typename Patch::TargetID)> isTargetAvailable{[](auto) { return true; }};
+
+    // Universal source filter: greys MACRO_MOD_k when that macro's power is off.
+    // Panels overriding sourceFilter should fall through to this.
+    SourceFilterResult sharedSourceFilter(int sid)
+    {
+        if (sid >= ModMatrixConfig::MACRO_MOD_0 &&
+            sid < (int)ModMatrixConfig::MACRO_MOD_0 + (int)numMacros)
+        {
+            int k = sid - (int)ModMatrixConfig::MACRO_MOD_0;
+            if (asComp()->editor.patchCopy.macroNodes[k].macroPower.value < 0.5f)
+                return SourceFilterResult::Disabled;
+        }
+        return SourceFilterResult::Include;
+    }
+
+    // Override per-panel to add extra rules; defaults to sharedSourceFilter.
+    std::function<SourceFilterResult(int)> sourceFilter{[this](int sid)
+                                                        { return sharedSourceFilter(sid); }};
 };
 } // namespace baconpaul::six_sines::ui
 #endif // MODULATION_COMPONENTS_H

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -38,6 +38,7 @@
 #include "ui-constants.h"
 #include "presets/preset-manager.h"
 #include "macro-panel.h"
+#include "macro-sub-panel.h"
 #include "clipboard.h"
 #include "patch-data-bindings.h"
 #include "preset-data-binding.h"
@@ -123,6 +124,8 @@ SixSinesEditor::SixSinesEditor(Synth::audioToUIQueue_t &atou, Synth::mainToAudio
     singlePanel->addChildComponent(*mainPanSubPanel);
     playModeSubPanel = std::make_unique<PlayModeSubPanel>(*this);
     singlePanel->addChildComponent(*playModeSubPanel);
+    macroSubPanel = std::make_unique<MacroSubPanel>(*this);
+    singlePanel->addChildComponent(*macroSubPanel);
 
     sst::jucegui::component_adapters::setTraversalId(sourcePanel.get(), 20000);
     sst::jucegui::component_adapters::setTraversalId(mainPanel.get(), 30000);
@@ -134,6 +137,33 @@ SixSinesEditor::SixSinesEditor(Synth::audioToUIQueue_t &atou, Synth::mainToAudio
     auto startMsg = Synth::MainToAudioMsg{Synth::MainToAudioMsg::REQUEST_REFRESH};
     mainToAudio.push(startMsg);
     requestParamsFlush();
+
+    // Build the routing-relevant param ID set once. Patch shape doesn't change
+    // at runtime, so this is a one-shot scan.
+    auto recordRouting = [this](auto &node)
+    {
+        for (int s = 0; s < numModsPer; ++s)
+        {
+            modRoutingParamIds.insert(node.modsource[s].meta.id);
+            modRoutingParamIds.insert(node.modtarget[s].meta.id);
+        }
+    };
+    for (auto &n : patchCopy.sourceNodes)
+        recordRouting(n);
+    for (auto &n : patchCopy.selfNodes)
+        recordRouting(n);
+    for (auto &n : patchCopy.mixerNodes)
+        recordRouting(n);
+    for (auto &n : patchCopy.matrixNodes)
+        recordRouting(n);
+    for (auto &n : patchCopy.macroNodes)
+        recordRouting(n);
+    recordRouting(patchCopy.output);
+    recordRouting(patchCopy.fineTuneMod);
+    recordRouting(patchCopy.mainPanMod);
+
+    onModulationRoutingChanged = [this]() { recomputeMacroUsage(); };
+    recomputeMacroUsage();
 
     idleTimer = std::make_unique<IdleTimer>(*this);
     idleTimer->startTimer(1000. / 60.);
@@ -232,6 +262,8 @@ void SixSinesEditor::idle()
         if (aum->action == Synth::AudioToUIMsg::UPDATE_PARAM)
         {
             setAndSendParamValue(aum->paramId, aum->value, false);
+            if (modRoutingParamIds.count(aum->paramId))
+                recomputeMacroUsage();
         }
         else if (aum->action == Synth::AudioToUIMsg::UPDATE_VU)
         {
@@ -254,6 +286,20 @@ void SixSinesEditor::idle()
             strncpy(patchCopy.name, aum->patchNamePointer, 255);
             setPatchNameDisplay();
         }
+        else if (aum->action == Synth::AudioToUIMsg::SET_MACRO_NAME)
+        {
+            auto idx = aum->paramId;
+            if (idx < numMacros && aum->patchNamePointer)
+            {
+                auto &buf = patchCopy.macroNames[idx];
+                std::fill(buf.begin(), buf.end(), 0);
+                strncpy(buf.data(), aum->patchNamePointer, buf.size() - 1);
+                if (macroPanel)
+                    macroPanel->refreshLabel(idx);
+                if (macroSubPanel && macroSubPanel->isVisible() && macroSubPanel->index == idx)
+                    macroSubPanel->refreshNameFromPatch();
+            }
+        }
         else if (aum->action == Synth::AudioToUIMsg::SET_PATCH_DIRTY_STATE)
         {
             patchCopy.dirty = (bool)aum->paramId;
@@ -267,8 +313,12 @@ void SixSinesEditor::idle()
                     clapHost->get_extension(clapHost, CLAP_EXT_PARAMS));
             if (clapParamsExtension)
             {
-                clapParamsExtension->rescan(clapHost,
-                                            CLAP_PARAM_RESCAN_VALUES | CLAP_PARAM_RESCAN_TEXT);
+                // RESCAN_INFO is mutually exclusive with VALUES/TEXT — honour an
+                // explicit flag in paramId when set, default otherwise.
+                auto flags = aum->paramId != 0
+                                 ? aum->paramId
+                                 : (uint32_t)(CLAP_PARAM_RESCAN_VALUES | CLAP_PARAM_RESCAN_TEXT);
+                clapParamsExtension->rescan(clapHost, flags);
                 clapParamsExtension->request_flush(clapHost);
             }
         }
@@ -456,6 +506,7 @@ void SixSinesEditor::resized()
     mainPanSubPanel->setBounds(singlePanel->getContentArea());
     fineTuneSubPanel->setBounds(singlePanel->getContentArea());
     playModeSubPanel->setBounds(singlePanel->getContentArea());
+    macroSubPanel->setBounds(singlePanel->getContentArea());
 }
 
 void SixSinesEditor::hideAllSubPanels()
@@ -468,6 +519,7 @@ void SixSinesEditor::hideAllSubPanels()
     sourcePanel->clearHighlight();
     matrixPanel->clearHighlight();
     mixerPanel->clearHighlight();
+    macroPanel->clearHighlight();
     settingsPanel->clearHighlight();
 }
 
@@ -889,6 +941,26 @@ void SixSinesEditor::postPatchChange(const std::string &s)
     for (auto [id, f] : componentRefreshByID)
         f();
 
+    recomputeMacroUsage();
+    repaint();
+}
+
+void SixSinesEditor::recomputeMacroUsage()
+{
+    macroUsageCache = computeMacroUsage(patchCopy);
+    if (macroPanel)
+    {
+        for (size_t i = 0; i < numMacros; ++i)
+        {
+            auto used = !macroUsageCache[i].empty();
+            if (macroPanel->knobs[i])
+                macroPanel->knobs[i]->setEnabled(used);
+        }
+    }
+    if (macroSubPanel && macroSubPanel->isVisible())
+        macroSubPanel->refreshUsedByList();
+
+    // Force a repaint; JUCE otherwise leaves setEnabled() changes until hover.
     repaint();
 }
 

--- a/src/ui/six-sines-editor.h
+++ b/src/ui/six-sines-editor.h
@@ -18,6 +18,7 @@
 
 #include <concepts>
 #include <functional>
+#include <unordered_set>
 #include <utility>
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "sst/jucegui/style/JUCELookAndFeelAdapter.h"
@@ -35,6 +36,7 @@
 #include <sst/jucegui/screens/ColorEditor.h>
 
 #include "synth/synth.h"
+#include "synth/macro_usage.h"
 #include "presets/preset-manager.h"
 #include "presets/ui-theme-manager.h"
 #include "ui-defaults.h"
@@ -66,6 +68,7 @@ struct PlayModeSubPanel;
 struct SourcePanel;
 struct SourceSubPanel;
 struct MacroPanel;
+struct MacroSubPanel;
 struct SettingsPanel;
 struct Clipboard;
 struct PresetDataBinding;
@@ -112,6 +115,7 @@ struct SixSinesEditor : jcmp::WindowPanel
     std::unique_ptr<MixerSubPanel> mixerSubPanel;
 
     std::unique_ptr<MacroPanel> macroPanel;
+    std::unique_ptr<MacroSubPanel> macroSubPanel;
     std::unique_ptr<SettingsPanel> settingsPanel;
 
     std::unique_ptr<SourcePanel> sourcePanel;
@@ -185,6 +189,14 @@ struct SixSinesEditor : jcmp::WindowPanel
     void hideAllSubPanels();
     std::unordered_map<uint32_t, juce::Component::SafePointer<juce::Component>> componentByID;
     std::unordered_map<uint32_t, std::function<void()>> componentRefreshByID;
+
+    // Per-macro list of consumers. Recomputed event-driven on post-load,
+    // UPDATE_PARAM (gated by modRoutingParamIds) and onModulationRoutingChanged.
+    std::array<std::vector<MacroUsedRef>, numMacros> macroUsageCache;
+    void recomputeMacroUsage();
+    std::unordered_set<uint32_t> modRoutingParamIds;
+    // Fired by ModulationComponents after a UI commit of modsource/modtarget.
+    std::function<void()> onModulationRoutingChanged{nullptr};
 
     void setAndSendParamValue(uint32_t id, float value, bool notifyAudio = true,
                               bool includeBeginEnd = true);


### PR DESCRIPTION
Macros become full mod sources with their own DAHDSR + LFO + 3-slot mod matrix, gated by a per-macro power toggle. With power off a macro behaves exactly like the previous static level; with power on it runs per-voice and contributes a modulated value.

Adds two entries per macro to the mod source list:

  MACRO_n      — static level, mono, behaves as before
  MACRO_MOD_n  — per-voice modulated output (env / LFO / mod matrix)

Macro→macro routing is constrained to lower-indexed macros (UI excludes self/higher; debug assert in DSP). MACRO_MOD entries grey out when the target macro's power is off.

Each macro gains env mode (add/scale), env depth, and lfo depth controls. Defaults: scale mode, env depth 0, lfo depth 1, power off (so v9 patches are unchanged).

Macro names are user-editable, persist in the patch, propagate to the CLAP host's param-list, and round-trip through save/load and shared .sxsnp files.

Clicking any macro knob opens a sub-panel with the env, LFO, mod matrix, depth row, name editor, and a "used by" listing of every node currently referencing that macro.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>