### PR TITLE
Add a spectrum analyzer + scope window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(${PROJECT_NAME}-impl STATIC
         src/clap/preset-discovery-impl.cpp
 
         src/ui/six-sines-editor.cpp
+        src/ui/spectrum-analyzer.cpp
 
         src/ui/clipboard.cpp
         src/ui/main-panel.cpp
@@ -100,6 +101,7 @@ target_link_libraries(${PROJECT_NAME}-impl PUBLIC  # PW change to public since w
         sst-plugininfra::patchbase
         sst-plugininfra::version_information
         sst::clap_juce_shim sst::clap_juce_shim_headers
+        juce::juce_dsp
         ${PROJECT_NAME}-patches
         ${PROJECT_NAME}-themes
         samplerate

--- a/src/clap/six-sines-clap.cpp
+++ b/src/clap/six-sines-clap.cpp
@@ -465,7 +465,7 @@ struct SixSinesClap : public plugHelper_t, sst::clap_juce_shim::EditorProvider
     std::unique_ptr<juce::Component> createEditor() override
     {
         auto res = std::make_unique<baconpaul::six_sines::ui::SixSinesEditor>(
-            engine->audioToUi, engine->mainToAudio, _host.host());
+            engine->audioToUi, engine->mainToAudio, engine->audioOutputRing, _host.host());
 
         res->onZoomChanged = [this](auto f)
         {

--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -528,9 +528,15 @@ template <bool multiOut> void Synth::processInternal(const clap_output_events_t 
         }
     }
 
-    // Finish CPU calculation
     if (isEditorAttached)
     {
+        // Tap host-SR main bus for visualizers (only when someone is listening).
+        if (audioOutputRing.subscribed())
+        {
+            audioOutputRing.push(output[0], output[1], blockSize);
+        }
+
+        // Finish CPU calculation
         auto end = std::chrono::high_resolution_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
         auto micros = duration.count();

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -383,6 +383,10 @@ struct Synth
     using mainToAudioQueue_T = sst::cpputils::SimpleRingBuffer<MainToAudioMsg, 1024 * 64>;
     audioToUIQueue_t audioToUi;
     mainToAudioQueue_T mainToAudio;
+
+    // Stereo audio tap for visualizers; ~1.4s @ 96kHz / 2.7s @ 48kHz.
+    using audioOutputQueue_t = sst::cpputils::StereoRingBuffer<float, 1024 * 128>;
+    audioOutputQueue_t audioOutputRing;
     std::atomic<bool> doFullRefresh{false};
     bool isEditorAttached{false};
     sst::basic_blocks::dsp::UIComponentLagHandler lagHandler;

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -41,6 +41,9 @@
 #include "ui-constants.h"
 #include "presets/preset-manager.h"
 #include "macro-panel.h"
+#include "spectrum-analyzer.h"
+#include <sst/jucegui/components/GlyphButton.h>
+#include <sst/jucegui/components/ButtonPainter.h>
 #include "macro-sub-panel.h"
 #include "clipboard.h"
 #include "patch-data-bindings.h"
@@ -66,13 +69,49 @@ struct DesPushTimer : juce::Timer
     }
 };
 
+// Toggle button for the analyzer window. Reuses GlyphButton's chrome and draws a tiny
+// sawtooth-style spectrum (bars at 1/n amplitude) as the glyph.
+struct AnalyzerToggleButton : sst::jucegui::components::GlyphButton
+{
+    AnalyzerToggleButton() : GlyphButton(sst::jucegui::components::GlyphPainter::CLOSE) {}
+    void paint(juce::Graphics &g) override
+    {
+        if (!style())
+            return;
+
+        sst::jucegui::components::paintButtonBG(this, g);
+        g.setColour(style()->getColour(jcmp::base_styles::ValueBearing::styleClass,
+                                       jcmp::base_styles::ValueBearing::value));
+        if (isHovered)
+            g.setColour(style()->getColour(jcmp::base_styles::ValueBearing::styleClass,
+                                           jcmp::base_styles::ValueBearing::value_hover));
+
+        auto bd = getLocalBounds().reduced(3);
+
+        auto dph = 2.0 * M_PI * 1.5 / bd.getWidth();
+        juce::Path p;
+        auto phase = 0.0;
+        for (int i = 0; i < bd.getWidth(); ++i)
+        {
+            phase += dph * (1.0 + 0.1 * sin(phase * 2.32));
+            auto bv = 0.6 * sin(phase) + 0.3 * sin(phase * 3.32);
+            auto sbv = (-bv + 1) * 0.5 * bd.getHeight();
+            if (i == 0)
+                p.startNewSubPath(i + bd.getX(), sbv + bd.getY());
+            else
+                p.lineTo(i + bd.getX(), sbv + bd.getY());
+        }
+        g.strokePath(p, juce::PathStrokeType(1.0f));
+    }
+};
+
 namespace jstl = sst::jucegui::style;
 using sheet_t = jstl::StyleSheet;
 static constexpr sheet_t::Class PatchMenu("six-sines.patch-menu");
 
 SixSinesEditor::SixSinesEditor(Synth::audioToUIQueue_t &atou, Synth::mainToAudioQueue_T &utoa,
-                               const clap_host_t *h)
-    : jcmp::WindowPanel(true), audioToUI(atou), mainToAudio(utoa), clapHost(h)
+                               Synth::audioOutputQueue_t &aor, const clap_host_t *h)
+    : jcmp::WindowPanel(true), audioToUI(atou), mainToAudio(utoa), audioOutputRing(aor), clapHost(h)
 {
     setTitle("Six Sines - an Audio Rate Modulation Synthesizer");
     setAccessible(true);
@@ -215,6 +254,16 @@ SixSinesEditor::SixSinesEditor(Synth::audioToUIQueue_t &atou, Synth::mainToAudio
     vuMeter = std::make_unique<jcmp::VUMeter>(jcmp::VUMeter::HORIZONTAL);
     addAndMakeVisible(*vuMeter);
 
+    analyzerToggleButton = std::make_unique<AnalyzerToggleButton>();
+    analyzerToggleButton->setOnCallback(
+        [w = juce::Component::SafePointer(this)]()
+        {
+            if (w)
+                w->toggleSpectrumAnalyzer();
+        });
+    analyzerToggleButton->setTitle("Toggle Analyzer Window");
+    addAndMakeVisible(*analyzerToggleButton);
+
     if (defaultsProvider->getUserDefaultValue(Defaults::designModeRunAllNodes, false))
         sessionRunAllNodes = true;
     if (defaultsProvider->getUserDefaultValue(Defaults::designModeAllSoundsOffOnToggle, false))
@@ -332,6 +381,10 @@ void SixSinesEditor::idle()
         {
             engineSR = aum->value2;
             hostSR = aum->value;
+            if (spectrumWindow)
+                if (auto *c = dynamic_cast<SpectrumAnalyzerComponent *>(
+                        spectrumWindow->getContentComponent()))
+                    c->setHostSampleRate(hostSR);
             repaint();
         }
         else if (aum->action == Synth::AudioToUIMsg::SET_DAW_EXTRA_STATE)
@@ -451,17 +504,23 @@ void SixSinesEditor::resized()
 
     auto panelMargin{1};
 
-    // Top bar: [ preset | vu ]
+    // Top bar: [ preset | analyzer-toggle | vu ]
     auto topInner = presetArea.withTrimmedTop(uicMargin);
     int vuWidth = 150;
+    int analyzerW = topInner.getHeight();
 
     auto vuRect = juce::Rectangle<int>(getWidth() - uicMargin - vuWidth, topInner.getY(), vuWidth,
                                        topInner.getHeight());
     vuMeter->setBounds(vuRect);
 
+    auto analyzerRect = juce::Rectangle<int>(vuRect.getX() - uicMargin - analyzerW, topInner.getY(),
+                                             analyzerW, topInner.getHeight());
+    analyzerToggleButton->setBounds(analyzerRect);
+
     int presetLeft = 110;
-    auto presetRect = juce::Rectangle<int>(
-        presetLeft, topInner.getY(), vuRect.getX() - uicMargin - presetLeft, topInner.getHeight());
+    auto presetRect =
+        juce::Rectangle<int>(presetLeft, topInner.getY(),
+                             analyzerRect.getX() - uicMargin - presetLeft, topInner.getHeight());
     presetButton->setBounds(presetRect);
 
     auto sourceRect =
@@ -836,6 +895,14 @@ void SixSinesEditor::showPresetPopup()
     p.addSubMenu("Design Mode", dm);
 
     p.addSeparator();
+    p.addItem(spectrumWindow ? "Hide Analyzer" : "Show Analyzer",
+              [w = juce::Component::SafePointer(this)]()
+              {
+                  if (w)
+                      w->toggleSpectrumAnalyzer();
+              });
+
+    p.addSeparator();
     p.addItem("Read the Manual",
               []()
               {
@@ -1178,7 +1245,41 @@ void SixSinesEditor::showNavigationMenu()
                   }
               });
 
+    p.addSeparator();
+    p.addItem(spectrumWindow ? "Hide Analyzer" : "Show Analyzer",
+              [w = juce::Component::SafePointer(this)]()
+              {
+                  if (w)
+                      w->toggleSpectrumAnalyzer();
+              });
+
     p.showMenuAsync(juce::PopupMenu::Options().withParentComponent(this));
+}
+
+void SixSinesEditor::showSpectrumAnalyzer()
+{
+    if (spectrumWindow)
+    {
+        spectrumWindow->toFront(true);
+        return;
+    }
+    auto comp = std::make_unique<SpectrumAnalyzerComponent>(audioOutputRing, hostSR,
+                                                            defaultsProvider.get());
+    spectrumWindow = std::make_unique<SpectrumAnalyzerWindow>(std::move(comp));
+    spectrumWindow->onCloseRequested = [w = juce::Component::SafePointer(this)]()
+    {
+        if (w)
+            w->spectrumWindow.reset();
+    };
+    spectrumWindow->setVisible(true);
+}
+
+void SixSinesEditor::toggleSpectrumAnalyzer()
+{
+    if (spectrumWindow)
+        spectrumWindow.reset();
+    else
+        showSpectrumAnalyzer();
 }
 
 bool SixSinesEditor::keyPressed(const juce::KeyPress &key)

--- a/src/ui/six-sines-editor.h
+++ b/src/ui/six-sines-editor.h
@@ -81,10 +81,11 @@ struct SixSinesEditor : jcmp::WindowPanel, sst::jucegui::screens::ScreenHolder<S
 
     Synth::audioToUIQueue_t &audioToUI;
     Synth::mainToAudioQueue_T &mainToAudio;
+    Synth::audioOutputQueue_t &audioOutputRing;
     const clap_host_t *clapHost{nullptr};
 
     SixSinesEditor(Synth::audioToUIQueue_t &atou, Synth::mainToAudioQueue_T &utoa,
-                   const clap_host_t *ch);
+                   Synth::audioOutputQueue_t &aor, const clap_host_t *ch);
     virtual ~SixSinesEditor();
 
     std::unique_ptr<sst::jucegui::style::LookAndFeelManager> lnf;
@@ -178,6 +179,13 @@ struct SixSinesEditor : jcmp::WindowPanel, sst::jucegui::screens::ScreenHolder<S
     // Safe pointer to the ColorEditorContent (a WindowPanel subclass) so that
     // onStyleChanged() can propagate style changes to the floating colour editor window.
     juce::Component::SafePointer<jcmp::WindowPanel> colorEditorContent;
+
+    // Spectrum analyzer floating window. Lifecycle: created on showSpectrumAnalyzer(),
+    // destroyed on close (which unsubscribes the audio ring and joins the analysis thread).
+    std::unique_ptr<struct SpectrumAnalyzerWindow> spectrumWindow;
+    void showSpectrumAnalyzer();
+    void toggleSpectrumAnalyzer();
+    std::unique_ptr<struct AnalyzerToggleButton> analyzerToggleButton;
 
     std::unique_ptr<jcmp::ToolTip> toolTip;
     void showTooltipOn(juce::Component *c);

--- a/src/ui/spectrum-analyzer.cpp
+++ b/src/ui/spectrum-analyzer.cpp
@@ -1,0 +1,607 @@
+/*
+ * Six Sines
+ *
+ * A synth with audio rate modulation.
+ *
+ * Copyright 2024-2025, Paul Walker and Various authors, as described in the github
+ * transaction log.
+ *
+ * This source repo is released under the MIT license, but has
+ * GPL3 dependencies, as such the combined work will be
+ * released under GPL3.
+ *
+ * The source code and license are at https://github.com/baconpaul/six-sines
+ */
+
+#include "ui/spectrum-analyzer.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+
+namespace baconpaul::six_sines::ui
+{
+
+namespace
+{
+// dB range for both spectrogram colormap and line plot
+constexpr float dbMin = -96.f;
+constexpr float dbMax = 0.f;
+
+// Magma-ish 5-stop gradient, lerped at paint time
+constexpr std::array<std::array<uint8_t, 3>, 5> colormap = {{
+    {0, 0, 4},       // black
+    {40, 11, 84},    // deep purple
+    {140, 41, 129},  // magenta
+    {241, 96, 93},   // coral
+    {252, 253, 191}, // pale yellow
+}};
+
+juce::Colour colorFor(float t)
+{
+    t = std::clamp(t, 0.f, 1.f);
+    constexpr int n = (int)colormap.size();
+    auto x = t * (n - 1);
+    auto i = std::min((int)x, n - 2);
+    auto f = x - i;
+    auto lerp = [f](uint8_t a, uint8_t b) { return (uint8_t)std::round(a + (b - a) * f); };
+    return juce::Colour(lerp(colormap[i][0], colormap[i + 1][0]),
+                        lerp(colormap[i][1], colormap[i + 1][1]),
+                        lerp(colormap[i][2], colormap[i + 1][2]));
+}
+
+float magToNorm(float mag)
+{
+    auto db = 20.f * std::log10(std::max(mag, 1e-12f));
+    return (db - dbMin) / (dbMax - dbMin);
+}
+} // namespace
+
+SpectrumAnalyzerComponent::SpectrumAnalyzerComponent(Synth::audioOutputQueue_t &r, float hostSr,
+                                                     defaultsProvder_t *d)
+    : ring(r), defaults(d)
+{
+    if (hostSr > 0.f)
+        hostSampleRate = hostSr;
+    setOpaque(true);
+    setSize(720, 690);
+
+    int savedMode = defaultModeIdx;
+    int savedScale = defaultScopeScale;
+    if (defaults)
+    {
+        savedMode = defaults->getUserDefaultValue(Defaults::spectrumAnalysisMode, defaultModeIdx);
+        savedScale = defaults->getUserDefaultValue(Defaults::spectrumScopeScale, defaultScopeScale);
+    }
+    if (savedMode < 0 || savedMode >= (int)modes.size())
+        savedMode = defaultModeIdx;
+    if (savedScale < 1 || savedScale > (int)scopeScales.back())
+        savedScale = defaultScopeScale;
+    scopeScale = savedScale;
+    lastSavedModeIdx = savedMode;
+
+    applyMode(savedMode);
+}
+
+void SpectrumAnalyzerComponent::setHostSampleRate(float sr)
+{
+    if (sr <= 0.f)
+        return;
+    if (std::abs(sr - hostSampleRate) < 1.f)
+        return;
+    hostSampleRate = sr;
+    applyMode(modeIdx);
+}
+
+SpectrumAnalyzerComponent::~SpectrumAnalyzerComponent()
+{
+    running = false;
+    if (analysisThread.joinable())
+        analysisThread.join();
+
+    ring.unsubscribe();
+    ring.clear();
+}
+
+void SpectrumAnalyzerComponent::resized() {}
+
+void SpectrumAnalyzerComponent::mouseDown(const juce::MouseEvent &e)
+{
+    if (!e.mods.isPopupMenu())
+        return;
+    juce::PopupMenu m;
+    m.addSectionHeader("Resolution");
+    for (int i = 0; i < (int)modes.size(); ++i)
+    {
+        m.addItem(modes[i].label, true, i == modeIdx,
+                  [w = juce::Component::SafePointer(this), i]()
+                  {
+                      if (w)
+                          w->applyMode(i);
+                  });
+    }
+    m.addSeparator();
+    m.addSectionHeader("Waveform Scale");
+    for (auto s : scopeScales)
+    {
+        m.addItem(juce::String(s) + "x", true, s == scopeScale,
+                  [w = juce::Component::SafePointer(this), s]()
+                  {
+                      if (w)
+                          w->setScopeScale(s);
+                  });
+    }
+    m.showMenuAsync(juce::PopupMenu::Options());
+}
+
+void SpectrumAnalyzerComponent::handleAsyncUpdate() { repaint(); }
+
+void SpectrumAnalyzerComponent::applyMode(int newIdx)
+{
+    bool wasRunning = running.exchange(false);
+    if (analysisThread.joinable())
+        analysisThread.join();
+
+    ring.unsubscribe();
+    ring.clear();
+
+    modeIdx = newIdx;
+    fftOrder = modes[modeIdx].fftOrder;
+    fftSize = 1 << fftOrder;
+    hopSize = modes[modeIdx].hopSize;
+    numBins = fftSize / 2;
+
+    fft = std::make_unique<juce::dsp::FFT>(fftOrder);
+    hann = std::make_unique<juce::dsp::WindowingFunction<float>>(
+        (size_t)fftSize, juce::dsp::WindowingFunction<float>::hann);
+
+    windowBuffer.assign(fftSize, 0.f);
+    windowFill = 0;
+    fftScratch.assign(2 * fftSize, 0.f);
+    col.assign(numBins, 0.f);
+
+    // Scope window: 20 ms regardless of mode.
+    scopeFrameLen = std::max(64, (int)std::round(0.02f * hostSampleRate));
+    scopeBuilding.assign(scopeFrameLen, 0.f);
+    scopeFill = 0;
+    scopeWaitingForTrigger = false;
+    scopePrev = 0.f;
+
+    {
+        std::lock_guard<std::mutex> lk(snapshotMutex);
+        columns.assign((size_t)spectrogramColumns * numBins, 0.f);
+        nextColumn = 0;
+        latestLine.assign(numBins, 0.f);
+        peakLine.assign(numBins, 0.f);
+        scopeFrame.assign(scopeFrameLen, 0.f);
+        spectrumVersion.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    // Paint-side scratch resized once per mode change so paint never allocates.
+    paintCols.assign((size_t)spectrogramColumns * numBins, 0.f);
+    paintLine.assign(numBins, 0.f);
+    paintPeak.assign(numBins, 0.f);
+    paintScope.assign(scopeFrameLen, 0.f);
+    paintNextColumn = 0;
+    cachedSpecImage = juce::Image();
+    cachedSpecImageH = 0;
+    lastPaintedSpectrumVersion = (uint32_t)-1;
+
+    auto framePeriod = (float)hopSize / hostSampleRate;
+    constexpr float halfLife = 1.2f;
+    peakDecay = std::pow(0.5f, framePeriod / halfLife);
+
+    if (wasRunning || !analysisThread.joinable())
+    {
+        ring.subscribe();
+        running = true;
+        analysisThread = std::thread(&SpectrumAnalyzerComponent::analysisThreadMain, this);
+    }
+    if (defaults && modeIdx != lastSavedModeIdx)
+    {
+        defaults->updateUserDefaultValue(Defaults::spectrumAnalysisMode, modeIdx);
+        lastSavedModeIdx = modeIdx;
+    }
+    repaint();
+}
+
+void SpectrumAnalyzerComponent::setScopeScale(int s)
+{
+    scopeScale = s;
+    if (defaults)
+        defaults->updateUserDefaultValue(Defaults::spectrumScopeScale, s);
+    repaint();
+}
+
+void SpectrumAnalyzerComponent::analysisThreadMain()
+{
+    int newSamples = 0;
+
+    while (running.load(std::memory_order_relaxed))
+    {
+        // Drain whatever audio is available, mono-summed into windowBuffer with wrap.
+        bool drained = false;
+        while (auto p = ring.pop())
+        {
+            auto m = 0.5f * (p->first + p->second);
+            windowBuffer[windowFill % fftSize] = m;
+            windowFill++;
+            newSamples++;
+            drained = true;
+
+            // Scope: collect a frame, then wait for next positive zero-crossing.
+            if (scopeWaitingForTrigger)
+            {
+                if (scopePrev <= 0.f && m > 0.f)
+                {
+                    scopeWaitingForTrigger = false;
+                    scopeFill = 0;
+                    scopeBuilding[scopeFill++] = m;
+                }
+            }
+            else
+            {
+                scopeBuilding[scopeFill++] = m;
+                if (scopeFill >= scopeFrameLen)
+                {
+                    {
+                        std::lock_guard<std::mutex> lk(snapshotMutex);
+                        std::copy(scopeBuilding.begin(), scopeBuilding.end(), scopeFrame.begin());
+                    }
+                    triggerAsyncUpdate();
+                    scopeWaitingForTrigger = true;
+                }
+            }
+            scopePrev = m;
+
+            // Cap per drain pass to keep things responsive.
+            if (newSamples >= hopSize && windowFill >= fftSize)
+                break;
+        }
+
+        if (!drained || windowFill < fftSize || newSamples < hopSize)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            continue;
+        }
+
+        // Compose the latest fftSize samples in time order from the wrap-around buffer.
+        auto start = (windowFill - fftSize) % fftSize;
+        if (start < 0)
+            start += fftSize;
+        for (int i = 0; i < fftSize; ++i)
+            fftScratch[i] = windowBuffer[(start + i) % fftSize];
+
+        std::fill(fftScratch.begin() + fftSize, fftScratch.end(), 0.f);
+        hann->multiplyWithWindowingTable(fftScratch.data(), (size_t)fftSize);
+        fft->performFrequencyOnlyForwardTransform(fftScratch.data());
+
+        // Normalize: 1/N for FFT, ~2 for Hann coherent gain
+        auto scale = 2.f / (float)fftSize;
+
+        for (int b = 0; b < numBins; ++b)
+            col[b] = magToNorm(fftScratch[b] * scale);
+
+        {
+            std::lock_guard<std::mutex> lk(snapshotMutex);
+            auto *dst = columns.data() + (size_t)nextColumn * numBins;
+            std::copy(col.begin(), col.end(), dst);
+            nextColumn = (nextColumn + 1) % spectrogramColumns;
+            std::copy(col.begin(), col.end(), latestLine.begin());
+            for (int b = 0; b < numBins; ++b)
+                peakLine[b] = std::max(col[b], peakLine[b] * peakDecay);
+            spectrumVersion.fetch_add(1, std::memory_order_relaxed);
+        }
+        triggerAsyncUpdate();
+
+        newSamples = 0;
+    }
+}
+
+float SpectrumAnalyzerComponent::magInRange(const float *c, float b0, float b1) const
+{
+    int ib0 = std::max(0, (int)std::floor(b0));
+    int ib1 = std::min(numBins - 1, (int)std::ceil(b1));
+    if (b1 - b0 < 1.f && ib0 + 1 < numBins)
+    {
+        // Sub-bin: linear interp between adjacent bins.
+        auto bf = 0.5f * (b0 + b1);
+        int bi = std::clamp((int)std::floor(bf), 0, numBins - 2);
+        auto f = bf - bi;
+        return c[bi] * (1.f - f) + c[bi + 1] * f;
+    }
+    float v = 0.f;
+    for (int b = ib0; b <= ib1; ++b)
+        v = std::max(v, c[b]);
+    return v;
+}
+
+void SpectrumAnalyzerComponent::paint(juce::Graphics &g)
+{
+    g.fillAll(juce::Colours::black);
+
+    constexpr int leftMargin = 38;
+    constexpr int bottomMargin = 14;
+    constexpr int splitGap = 4;
+    constexpr int scopeHeight = 132;
+    constexpr int lineHeight = 186;
+
+    auto bounds = getLocalBounds();
+    auto leftLabels = bounds.removeFromLeft(leftMargin);
+    auto scopeArea = bounds.removeFromBottom(scopeHeight);
+    bounds.removeFromBottom(splitGap);
+    auto freqLabels = bounds.removeFromBottom(bottomMargin);
+    auto lineArea = bounds.removeFromBottom(lineHeight);
+    bounds.removeFromBottom(splitGap);
+    auto specArea = bounds;
+
+    auto specRect = specArea.toFloat();
+    auto lineRect = lineArea.toFloat();
+    auto scopeRect = scopeArea.toFloat();
+
+    int snapNumBins = 0;
+    int snapFftSize = 0;
+    uint32_t snapVersion = 0;
+    {
+        std::lock_guard<std::mutex> lk(snapshotMutex);
+        snapNumBins = numBins;
+        snapFftSize = fftSize;
+        snapVersion = spectrumVersion.load(std::memory_order_relaxed);
+        // Always copy scope (changes asynchronously from spectrum); copy spectrum data
+        // only when something new arrived since the last paint.
+        if (paintScope.size() == scopeFrame.size())
+            std::copy(scopeFrame.begin(), scopeFrame.end(), paintScope.begin());
+        if (snapVersion != lastPaintedSpectrumVersion)
+        {
+            if (paintCols.size() == columns.size())
+                std::copy(columns.begin(), columns.end(), paintCols.begin());
+            if (paintLine.size() == latestLine.size())
+                std::copy(latestLine.begin(), latestLine.end(), paintLine.begin());
+            if (paintPeak.size() == peakLine.size())
+                std::copy(peakLine.begin(), peakLine.end(), paintPeak.begin());
+            paintNextColumn = nextColumn;
+        }
+    }
+
+    if (snapNumBins == 0)
+        return;
+
+    auto colDataAt = [&](int idx) { return paintCols.data() + (size_t)idx * snapNumBins; };
+
+    // Log-frequency mapping shared by spectrogram (y) and line plot (x).
+    constexpr float fmin = 20.f;
+    auto fmax = std::max(hostSampleRate * 0.5f, fmin * 2.f);
+    auto logRatio = std::log(fmax / fmin);
+    auto freqAt = [&](float t) { return fmin * std::exp(t * logRatio); };
+    auto tAt = [&](float f) { return std::log(f / fmin) / logRatio; };
+    auto binAt = [&](float f) { return f * (float)snapFftSize / hostSampleRate; };
+
+    // Spectrogram: a small (columns × pixelHeight) image is cached as a member, rebuilt
+    // only when geometry changes or new spectrum data has arrived since the last paint.
+    // Pixels are written via PixelARGB raw access (much faster than setPixelColour).
+    auto specPxH = specArea.getHeight();
+    if (specPxH > 0)
+    {
+        bool dimsChanged = (specPxH != cachedSpecImageH || !cachedSpecImage.isValid());
+        if (dimsChanged)
+        {
+            cachedSpecImage = juce::Image(juce::Image::ARGB, spectrogramColumns, specPxH, false);
+            cachedSpecImageH = specPxH;
+        }
+        if (dimsChanged || snapVersion != lastPaintedSpectrumVersion)
+        {
+            juce::Image::BitmapData bd(cachedSpecImage, juce::Image::BitmapData::writeOnly);
+            for (int prow = 0; prow < specPxH; ++prow)
+            {
+                auto t0 = (specPxH - 1 - prow) / (float)specPxH;
+                auto t1 = (specPxH - prow) / (float)specPxH;
+                auto b0 = binAt(freqAt(t0));
+                auto b1 = binAt(freqAt(t1));
+                auto *line = (juce::PixelARGB *)bd.getLinePointer(prow);
+                for (int c = 0; c < spectrogramColumns; ++c)
+                {
+                    auto idx = (paintNextColumn + c) % spectrogramColumns;
+                    auto v = magInRange(colDataAt(idx), b0, b1);
+                    auto col = colorFor(v);
+                    line[c] = juce::PixelARGB(255, col.getRed(), col.getGreen(), col.getBlue());
+                }
+            }
+            lastPaintedSpectrumVersion = snapVersion;
+        }
+        g.drawImage(cachedSpecImage, specRect);
+    }
+
+    auto dbToY = [&](float db)
+    {
+        auto v = (db - dbMin) / (dbMax - dbMin);
+        return lineRect.getBottom() - v * lineRect.getHeight();
+    };
+    static constexpr std::array<float, 9> ticks{50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000};
+
+    // Grid + line-plot drawing is clipped to lineArea: magToNorm can yield negative
+    // values (signals below dbMin), and stroked paths straddle getBottom() by half their
+    // width, so without a clip those bits leak into the labels strip.
+    {
+        juce::Graphics::ScopedSaveState ss(g);
+        g.reduceClipRegion(lineArea);
+
+        g.setColour(juce::Colour(0xff202020));
+        g.drawRect(lineRect, 1.f);
+        for (int db = -20; db >= -80; db -= 20)
+        {
+            auto y = dbToY((float)db);
+            g.drawHorizontalLine((int)y, lineRect.getX(), lineRect.getRight());
+        }
+        for (auto f : ticks)
+        {
+            if (f < fmin || f > fmax)
+                continue;
+            auto t = tAt(f);
+            auto x = lineRect.getX() + t * lineRect.getWidth();
+            g.drawVerticalLine((int)x, lineRect.getY(), lineRect.getBottom());
+        }
+
+        // Peak-hold trace (drawn first so live spectrum sits on top)
+        juce::Path peakPath;
+        {
+            bool first = true;
+            auto lineW = lineRect.getWidth();
+            auto pxW = std::max(1, (int)std::round(lineW));
+            for (int px = 0; px < pxW; ++px)
+            {
+                auto t0 = px / (float)pxW;
+                auto t1 = (px + 1) / (float)pxW;
+                auto v = magInRange(paintPeak.data(), binAt(freqAt(t0)), binAt(freqAt(t1)));
+                auto x = lineRect.getX() + t0 * lineW;
+                auto y = lineRect.getBottom() - v * lineRect.getHeight();
+                if (first)
+                {
+                    peakPath.startNewSubPath(x, y);
+                    first = false;
+                }
+                else
+                    peakPath.lineTo(x, y);
+            }
+        }
+        g.setColour(juce::Colour(0xff806030));
+        g.strokePath(peakPath, juce::PathStrokeType(1.f));
+
+        // Live line spectrum
+        juce::Path linePath;
+        {
+            bool first = true;
+            auto lineW = lineRect.getWidth();
+            auto pxW = std::max(1, (int)std::round(lineW));
+            for (int px = 0; px < pxW; ++px)
+            {
+                auto t0 = px / (float)pxW;
+                auto t1 = (px + 1) / (float)pxW;
+                auto v = magInRange(paintLine.data(), binAt(freqAt(t0)), binAt(freqAt(t1)));
+                auto x = lineRect.getX() + t0 * lineW;
+                auto y = lineRect.getBottom() - v * lineRect.getHeight();
+                if (first)
+                {
+                    linePath.startNewSubPath(x, y);
+                    first = false;
+                }
+                else
+                    linePath.lineTo(x, y);
+            }
+        }
+        g.setColour(juce::Colour(0xfff0c060));
+        g.strokePath(linePath, juce::PathStrokeType(1.5f));
+    }
+
+    // Labels (drawn outside the line-area clip)
+    g.setColour(juce::Colour(0xff808080));
+    g.setFont(10.f);
+
+    auto freqLabel = [](float f)
+    {
+        if (f >= 1000.f)
+        {
+            float k = f / 1000.f;
+            if (std::abs(k - std::round(k)) < 0.05f)
+                return juce::String((int)std::round(k)) + "k";
+            return juce::String(k, 1) + "k";
+        }
+        return juce::String((int)f);
+    };
+    for (auto f : ticks)
+    {
+        if (f < fmin || f > fmax)
+            continue;
+        auto x = lineRect.getX() + tAt(f) * lineRect.getWidth();
+        g.drawText(freqLabel(f), (int)x - 24, freqLabels.getY(), 48, freqLabels.getHeight(),
+                   juce::Justification::centred);
+    }
+    for (auto f : ticks)
+    {
+        if (f < fmin || f > fmax)
+            continue;
+        auto y = specRect.getBottom() - tAt(f) * specRect.getHeight();
+        g.drawText(freqLabel(f), leftLabels.getX(), (int)y - 6, leftMargin - 4, 12,
+                   juce::Justification::centredRight);
+    }
+    for (int db = 0; db >= -80; db -= 20)
+    {
+        auto y = dbToY((float)db);
+        g.drawText(juce::String(db), leftLabels.getX(), (int)y - 6, leftMargin - 4, 12,
+                   juce::Justification::centredRight);
+    }
+
+    // Scope: 20 ms left-to-right, retriggered at the next positive zero crossing.
+    // Samples beyond ±1 are clipped by the scope rect.
+    g.setColour(juce::Colour(0xff0a0a0a));
+    g.fillRect(scopeRect);
+    g.setColour(juce::Colour(0xff202020));
+    g.drawRect(scopeRect, 1.f);
+    {
+        juce::Graphics::ScopedSaveState ss(g);
+        g.reduceClipRegion(scopeArea);
+
+        auto cy = scopeRect.getCentreY();
+        auto halfH = scopeRect.getHeight() * 0.5f;
+        g.setColour(juce::Colour(0xff303030));
+        g.drawHorizontalLine((int)cy, scopeRect.getX(), scopeRect.getRight());
+        g.setColour(juce::Colour(0xff202020));
+        g.drawHorizontalLine((int)(cy - 0.5f * halfH), scopeRect.getX(), scopeRect.getRight());
+        g.drawHorizontalLine((int)(cy + 0.5f * halfH), scopeRect.getX(), scopeRect.getRight());
+
+        if (!paintScope.empty())
+        {
+            auto N = (int)paintScope.size();
+            auto W = scopeRect.getWidth();
+            auto X0 = scopeRect.getX();
+            juce::Path tracePath;
+            for (int i = 0; i < N; ++i)
+            {
+                auto x = X0 + (i / (float)(N - 1)) * W;
+                auto y = cy - paintScope[i] * (float)scopeScale * halfH;
+                if (i == 0)
+                    tracePath.startNewSubPath(x, y);
+                else
+                    tracePath.lineTo(x, y);
+            }
+            g.setColour(juce::Colour(0xfff0c060));
+            g.strokePath(tracePath, juce::PathStrokeType(1.f));
+        }
+    }
+
+    // Info overlays in the upper-left of each plot.
+    auto drawInfo = [&](juce::Rectangle<int> area, const juce::String &txt)
+    {
+        auto pad = 4;
+        auto box = juce::Rectangle<int>(area.getX() + pad, area.getY() + pad, 200, 14);
+        g.setColour(juce::Colour(0xa0000000));
+        g.fillRect(box);
+        g.setColour(juce::Colour(0xffc0c0c0));
+        g.setFont(10.f);
+        g.drawText(txt, box.reduced(4, 0), juce::Justification::centredLeft);
+    };
+    drawInfo(specArea, juce::String(fftSize) + "/" + juce::String(hopSize) + " - RMB to change");
+    drawInfo(scopeArea, juce::String(scopeScale) + "x - RMB to change");
+}
+
+SpectrumAnalyzerWindow::SpectrumAnalyzerWindow(std::unique_ptr<SpectrumAnalyzerComponent> content)
+    : juce::DocumentWindow("Six Sines Analyzer", juce::Colours::black,
+                           juce::DocumentWindow::closeButton)
+{
+    setUsingNativeTitleBar(true);
+    setResizable(true, false);
+    setContentOwned(content.release(), true);
+    setSize(720, 690);
+}
+
+void SpectrumAnalyzerWindow::closeButtonPressed()
+{
+    // Defer: deleting the window inside its own callback is fragile in JUCE.
+    juce::MessageManager::callAsync(
+        [cb = onCloseRequested]()
+        {
+            if (cb)
+                cb();
+        });
+}
+
+} // namespace baconpaul::six_sines::ui

--- a/src/ui/spectrum-analyzer.h
+++ b/src/ui/spectrum-analyzer.h
@@ -1,0 +1,146 @@
+/*
+ * Six Sines
+ *
+ * A synth with audio rate modulation.
+ *
+ * Copyright 2024-2025, Paul Walker and Various authors, as described in the github
+ * transaction log.
+ *
+ * This source repo is released under the MIT license, but has
+ * GPL3 dependencies, as such the combined work will be
+ * released under GPL3.
+ *
+ * The source code and license are at https://github.com/baconpaul/six-sines
+ */
+
+#ifndef BACONPAUL_SIX_SINES_UI_SPECTRUM_ANALYZER_H
+#define BACONPAUL_SIX_SINES_UI_SPECTRUM_ANALYZER_H
+
+#include <array>
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_dsp/juce_dsp.h>
+
+#include "synth/synth.h"
+#include "ui-defaults.h"
+
+namespace baconpaul::six_sines::ui
+{
+
+struct SpectrumAnalyzerComponent : juce::Component, private juce::AsyncUpdater
+{
+    static constexpr int spectrogramColumns = 256;
+
+    struct Mode
+    {
+        int fftOrder;
+        int hopSize;
+        const char *label;
+    };
+    static constexpr std::array<Mode, 4> modes{{
+        {11, 512, "2048 / 512"},
+        {12, 512, "4096 / 512"},
+        {13, 512, "8192 / 512"},
+        {14, 1024, "16384 / 1024"},
+    }};
+    static constexpr int defaultModeIdx = 2;
+
+    static constexpr std::array<int, 3> scopeScales{1, 2, 3};
+    static constexpr int defaultScopeScale = 1;
+
+    SpectrumAnalyzerComponent(Synth::audioOutputQueue_t &ring, float hostSampleRate,
+                              defaultsProvder_t *defaults = nullptr);
+    ~SpectrumAnalyzerComponent() override;
+
+    void paint(juce::Graphics &) override;
+    void resized() override;
+    void mouseDown(const juce::MouseEvent &) override;
+
+    // Pushed by the editor when the host sample rate changes; rebuilds buffers if needed.
+    void setHostSampleRate(float sr);
+
+  private:
+    void handleAsyncUpdate() override;
+    void analysisThreadMain();
+
+    // Tear down the worker, resize buffers, rebuild FFT/window for the given mode,
+    // then restart the worker. Called from the UI thread.
+    void applyMode(int modeIdx);
+    void setScopeScale(int s);
+
+    float magInRange(const float *col, float b0, float b1) const;
+
+    Synth::audioOutputQueue_t &ring;
+    float hostSampleRate{48000.f};
+    defaultsProvder_t *defaults{nullptr};
+    int scopeScale{defaultScopeScale};
+
+    int modeIdx{defaultModeIdx};
+    int lastSavedModeIdx{-1};
+    int fftOrder{};
+    int fftSize{};
+    int hopSize{};
+    int numBins{};
+
+    std::unique_ptr<juce::dsp::FFT> fft;
+    std::unique_ptr<juce::dsp::WindowingFunction<float>> hann;
+
+    // owned by the analysis thread
+    std::vector<float> windowBuffer;
+    int windowFill{0};
+    std::vector<float> fftScratch;
+    std::vector<float> col; // reused per-frame magnitude scratch
+
+    // Scope (raw oscilloscope), 20 ms window with positive zero-crossing retrigger.
+    int scopeFrameLen{};
+    std::vector<float> scopeBuilding; // analysis-thread only
+    int scopeFill{0};
+    bool scopeWaitingForTrigger{false};
+    float scopePrev{0.f};
+
+    // shared between analysis thread (writer) and UI thread (reader)
+    std::mutex snapshotMutex;
+    std::vector<float> columns; // flat: spectrogramColumns * numBins
+    int nextColumn{0};
+    std::vector<float> latestLine;
+    std::vector<float> peakLine;
+    std::vector<float> scopeFrame; // latest complete frame
+    // Bumped under the lock when columns/latestLine/peakLine change. Paint compares this
+    // against lastPaintedSpectrumVersion to skip the spectrogram-image rebuild when
+    // nothing new has arrived (e.g. a paint triggered by hover or resize).
+    std::atomic<uint32_t> spectrumVersion{0};
+
+    // UI-thread paint scratch — sized in applyMode so paint never allocates.
+    std::vector<float> paintCols;
+    std::vector<float> paintLine;
+    std::vector<float> paintPeak;
+    std::vector<float> paintScope;
+    int paintNextColumn{0};
+    juce::Image cachedSpecImage;
+    int cachedSpecImageH{0};
+    uint32_t lastPaintedSpectrumVersion{(uint32_t)-1};
+
+    // Peak-hold decay per analysis frame; depends on hop period and target half-life.
+    float peakDecay{0.995f};
+
+    std::thread analysisThread;
+    std::atomic<bool> running{false};
+};
+
+struct SpectrumAnalyzerWindow : juce::DocumentWindow
+{
+    explicit SpectrumAnalyzerWindow(std::unique_ptr<SpectrumAnalyzerComponent> content);
+    void closeButtonPressed() override;
+
+    std::function<void()> onCloseRequested;
+};
+
+} // namespace baconpaul::six_sines::ui
+
+#endif // BACONPAUL_SIX_SINES_UI_SPECTRUM_ANALYZER_H

--- a/src/ui/ui-defaults.h
+++ b/src/ui/ui-defaults.h
@@ -31,6 +31,8 @@ enum Defaults
     designModeRunAllNodes,
     designModeAllSoundsOffOnToggle,
     defaultAuthor,
+    spectrumAnalysisMode,
+    spectrumScopeScale,
     numDefaults
 };
 
@@ -52,6 +54,10 @@ inline std::string defaultName(Defaults d)
         return "designModeAllSoundsOffOnToggle";
     case defaultAuthor:
         return "defaultAuthor";
+    case spectrumAnalysisMode:
+        return "spectrumAnalysisMode";
+    case spectrumScopeScale:
+        return "spectrumScopeScale";
     case numDefaults:
     {
         SXSNLOG("Software Error - defaults found");


### PR DESCRIPTION
Adds an in-plugin Analyzer floating window with three views: a log-frequency scrolling spectrogram, a windowed-FFT line spectrum with peak hold, and a 20 ms oscilloscope that retriggers on the next positive zero crossing. Resolution (FFT size / hop) and waveform amplitude scale are user-selectable via a right-click popup on the analyzer surface and persist across launches as user defaults. Host sample rate changes propagate live to the open analyzer.

A square toggle button between the patch menu and VU meter opens and closes the window; the same toggle is mirrored in the navigation and patch popups, with the menu label flipping between Show and Hide based on current state.

Threading and lifecycle: the synth pushes the host-rate main bus into a lock-free StereoRingBuffer that is gated by an atomic "subscribed" flag, so the audio thread does no work when no analyzer is open. A worker std::thread inside the analyzer drains the ring, runs the FFT and assembles a scope frame, and publishes its results under a small mutex that the UI thread holds only briefly. The UI is woken via juce::AsyncUpdater so the worker never touches JUCE state directly. Mode changes pause the worker, swap buffers, and restart it. The worker uses a version counter so that paint can skip the spectrogram-image rebuild when nothing new has arrived; pixels are written via raw juce::PixelARGB line pointers and all paint scratch is preallocated, so paint itself does not allocate. Window close defers via
juce::MessageManager::callAsync to avoid destroying the DocumentWindow from inside its own callback. Window destruction unsubscribes from the ring so the audio thread returns to its zero-cost state.

This change made heavy use of Opus during design and review.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>