### PR TITLE
Update the rescan mechanism

### DIFF
--- a/src/presets/preset-manager.cpp
+++ b/src/presets/preset-manager.cpp
@@ -287,6 +287,9 @@ void PresetManager::sendEntirePatchToAudio(Patch &patch, Synth::mainToAudioQueue
         msg.uiManagedPointer = macDat;
         mainToAudio.push(msg);
     }
+    // The audio-side SEND_MACRO_NAME handler decides whether each name actually
+    // changed and requests an INFO rescan only if so (atomic-OR coalesces the
+    // burst into a single host call).
 
     mainToAudio.push({Synth::MainToAudioMsg::STOP_AUDIO});
     for (const auto &p : patch.params)
@@ -296,8 +299,9 @@ void PresetManager::sendEntirePatchToAudio(Patch &patch, Synth::mainToAudioQueue
     }
     mainToAudio.push({Synth::MainToAudioMsg::START_AUDIO});
     mainToAudio.push({Synth::MainToAudioMsg::SEND_PATCH_IS_CLEAN, true});
+    // SEND_POST_LOAD's audio handler now requests the VALUES rescan via
+    // Synth::requestParamRescan, so no separate rescan message is needed here.
     mainToAudio.push({Synth::MainToAudioMsg::SEND_POST_LOAD, true});
-    mainToAudio.push({Synth::MainToAudioMsg::SEND_REQUEST_RESCAN, true});
 
     if (hostPar)
     {

--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -627,6 +627,10 @@ void Synth::processUIQueue(const clap_output_events_t *outq)
         doFullRefresh = false;
         didRefresh = true;
     }
+    // Accumulate rescan flags across the whole drain so we issue one
+    // requestParamRescan / request_callback at the end, regardless of how many
+    // messages in this batch wanted a rescan.
+    uint32_t pendingRescan{0};
     auto uiM = mainToAudio.pop();
     while (uiM.has_value())
     {
@@ -762,17 +766,18 @@ void Synth::processUIQueue(const clap_output_events_t *outq)
             if (idx < numMacros && uiM->uiManagedPointer)
             {
                 auto &buf = patch.macroNames[idx];
-                std::fill(buf.begin(), buf.end(), 0);
-                strncpy(buf.data(), uiM->uiManagedPointer, buf.size() - 1);
-                AudioToUIMsg out{AudioToUIMsg::SET_MACRO_NAME};
-                out.paramId = idx;
-                out.patchNamePointer = buf.data();
-                audioToUi.push(out);
-
-                // Refresh host param info so the renamed macro picks up its display name.
-                AudioToUIMsg rescan{AudioToUIMsg::DO_PARAM_RESCAN};
-                rescan.paramId = CLAP_PARAM_RESCAN_INFO;
-                audioToUi.push(rescan);
+                // Only act on actual changes — avoids gratuitous INFO rescans on
+                // preset loads where macro names match what the host already knows.
+                if (std::strncmp(buf.data(), uiM->uiManagedPointer, buf.size()) != 0)
+                {
+                    std::fill(buf.begin(), buf.end(), 0);
+                    strncpy(buf.data(), uiM->uiManagedPointer, buf.size() - 1);
+                    AudioToUIMsg out{AudioToUIMsg::SET_MACRO_NAME};
+                    out.paramId = idx;
+                    out.patchNamePointer = buf.data();
+                    audioToUi.push(out);
+                    pendingRescan |= RescanRequest::INFO;
+                }
             }
         }
         break;
@@ -785,18 +790,13 @@ void Synth::processUIQueue(const clap_output_events_t *outq)
         case MainToAudioMsg::SEND_POST_LOAD:
         {
             postLoad();
+            // Preset load just rewrote every param value — let the host re-read.
+            pendingRescan |= RescanRequest::VALUES;
         }
         break;
         case MainToAudioMsg::SEND_PREP_FOR_STREAM:
         {
             prepForStream();
-        }
-        break;
-        case MainToAudioMsg::SEND_REQUEST_RESCAN:
-        {
-            onMainRescanParams = true;
-            audioToUi.push({AudioToUIMsg::DO_PARAM_RESCAN});
-            clapHost->request_callback(clapHost);
         }
         break;
         case MainToAudioMsg::EDITOR_ATTACH_DETATCH:
@@ -830,6 +830,10 @@ void Synth::processUIQueue(const clap_output_events_t *outq)
         }
         uiM = mainToAudio.pop();
     }
+
+    // One coalesced rescan request per drain pass.
+    if (pendingRescan)
+        requestParamRescan(pendingRescan);
 }
 
 void Synth::reapplyControlSettings()
@@ -930,16 +934,26 @@ void Synth::resetSoloState()
 
 void Synth::onMainThread()
 {
-    bool ex{true}, re{false};
-    if (onMainRescanParams.compare_exchange_strong(ex, re))
-    {
-        auto pe = static_cast<const clap_host_params_t *>(
-            clapHost->get_extension(clapHost, CLAP_EXT_PARAMS));
-        if (pe)
-        {
-            pe->rescan(clapHost, CLAP_PARAM_RESCAN_VALUES | CLAP_PARAM_RESCAN_TEXT);
-        }
-    }
+    auto flags = onMainRescanFlags.exchange(0, std::memory_order_acquire);
+    if (flags == 0 || !clapHost)
+        return;
+    auto pe =
+        static_cast<const clap_host_params_t *>(clapHost->get_extension(clapHost, CLAP_EXT_PARAMS));
+    if (!pe)
+        return;
+    // CLAP says INFO is mutually exclusive with VALUES; issue separately.
+    if (flags & RescanRequest::VALUES)
+        pe->rescan(clapHost, CLAP_PARAM_RESCAN_VALUES);
+    if (flags & RescanRequest::INFO)
+        pe->rescan(clapHost, CLAP_PARAM_RESCAN_INFO);
+}
+
+void Synth::requestParamRescan(uint32_t flags)
+{
+    if (flags == 0 || !clapHost)
+        return;
+    onMainRescanFlags.fetch_or(flags, std::memory_order_release);
+    clapHost->request_callback(clapHost);
 }
 
 } // namespace baconpaul::six_sines

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -339,8 +339,6 @@ struct Synth
             UPDATE_CPU_USAGE,
             SET_PATCH_NAME,
             SET_PATCH_DIRTY_STATE,
-            DO_PARAM_RESCAN, // paramId optionally carries CLAP_PARAM_RESCAN_*
-                             // flags; 0 falls back to VALUES|TEXT
 
             SEND_SAMPLE_RATE,
             SET_DAW_EXTRA_STATE,
@@ -366,7 +364,6 @@ struct Synth
             SEND_PATCH_AUTHOR,
             SEND_PATCH_IS_CLEAN,
             SEND_POST_LOAD,
-            SEND_REQUEST_RESCAN,
             EDITOR_ATTACH_DETATCH, // paramid is true for attach and false for detach
             SEND_PREP_FOR_STREAM,
             PANIC_STOP_VOICES,
@@ -379,6 +376,20 @@ struct Synth
         const char *uiManagedPointer{nullptr};
         const void *dawExtraStatePointer{nullptr};
     };
+
+    // Rescan request flags accumulated in onMainRescanFlags. Bit positions match
+    // CLAP's CLAP_PARAM_RESCAN_* so onMainThread can map them with no translation.
+    // The indirection lets non-CLAP layers stay CLAP-header-clean.
+    enum RescanRequest : uint32_t
+    {
+        VALUES = 1 << 0,
+        INFO = 1 << 2,
+        ALL = VALUES | INFO
+    };
+
+    // Thread-safe; accumulates flags and asks the host to call us back on the main
+    // thread, where onMainThread() will issue the actual clap rescans.
+    void requestParamRescan(uint32_t flags);
     using audioToUIQueue_t = sst::cpputils::SimpleRingBuffer<AudioToUIMsg, 1024 * 16>;
     using mainToAudioQueue_T = sst::cpputils::SimpleRingBuffer<MainToAudioMsg, 1024 * 64>;
     audioToUIQueue_t audioToUi;
@@ -422,7 +433,7 @@ struct Synth
         }
     }
 
-    std::atomic<bool> onMainRescanParams{false};
+    std::atomic<uint32_t> onMainRescanFlags{0};
     void onMainThread();
 
     void reapplyControlSettings();

--- a/src/ui/macro-sub-panel.cpp
+++ b/src/ui/macro-sub-panel.cpp
@@ -378,6 +378,8 @@ void MacroSubPanel::commitName()
     msg.paramId = static_cast<uint32_t>(index);
     msg.uiManagedPointer = buf.data();
     editor.mainToAudio.push(msg);
+    // The audio-side SEND_MACRO_NAME handler diffs against the current name and
+    // requests an INFO rescan via Synth::requestParamRescan when it actually changes.
 
     if (editor.macroPanel && index < editor.macroPanel->labels.size() &&
         editor.macroPanel->labels[index])

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -361,22 +361,6 @@ void SixSinesEditor::idle()
             presetDataBinding->setDirtyState(patchCopy.dirty);
             presetButton->repaint();
         }
-        else if (aum->action == Synth::AudioToUIMsg::DO_PARAM_RESCAN)
-        {
-            if (!clapParamsExtension)
-                clapParamsExtension = static_cast<const clap_host_params_t *>(
-                    clapHost->get_extension(clapHost, CLAP_EXT_PARAMS));
-            if (clapParamsExtension)
-            {
-                // RESCAN_INFO is mutually exclusive with VALUES/TEXT — honour an
-                // explicit flag in paramId when set, default otherwise.
-                auto flags = aum->paramId != 0
-                                 ? aum->paramId
-                                 : (uint32_t)(CLAP_PARAM_RESCAN_VALUES | CLAP_PARAM_RESCAN_TEXT);
-                clapParamsExtension->rescan(clapHost, flags);
-                clapParamsExtension->request_flush(clapHost);
-            }
-        }
         else if (aum->action == Synth::AudioToUIMsg::SEND_SAMPLE_RATE)
         {
             engineSR = aum->value2;


### PR DESCRIPTION
Update the param rescan mechanism to

1: always use onMainThread and not the UI loop
2: Be way more parsimonious

Reducing a multi-rescan macro patch load case introduced with super macros due to lingering design problems from 1.1

Assisted-By: Opus 4.7