### PR TITLE
Add a segmented-decimal ratio editor for source operators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(${PROJECT_NAME}-impl STATIC
         src/ui/mixer-sub-panel.cpp
         src/ui/source-panel.cpp
         src/ui/source-sub-panel.cpp
+        src/ui/segmented-ratio-editor.cpp
         src/ui/macro-panel.cpp
         src/ui/macro-sub-panel.cpp
         src/ui/finetune-sub-panel.cpp

--- a/doc/12_roadmap.md
+++ b/doc/12_roadmap.md
@@ -39,11 +39,9 @@ Probably want a legacy mode of knob
   - windows ui open isn't right
   - jack on linux
 
-## Visualization
+## Visualization **DONE**
 
-- That fun explicig DFT as spectrum
-- Show the wavetable somehow?
-- or maybe do none of this
+- Add a simple built in spectrum and scope
 
 ## Super-Macros **DONE**
 

--- a/src/ui/segmented-ratio-editor.cpp
+++ b/src/ui/segmented-ratio-editor.cpp
@@ -1,0 +1,374 @@
+/*
+ * Six Sines
+ *
+ * A synth with audio rate modulation.
+ *
+ * Copyright 2024-2025, Paul Walker and Various authors, as described in the github
+ * transaction log.
+ *
+ * This source repo is released under the MIT license, but has
+ * GPL3 dependencies, as such the combined work will be
+ * released under GPL3.
+ *
+ * The source code and license are at https://github.com/baconpaul/six-sines
+ */
+
+#include "segmented-ratio-editor.h"
+#include <cmath>
+#include <algorithm>
+
+namespace baconpaul::six_sines::ui
+{
+
+namespace jcmp = sst::jucegui::components;
+namespace jdat = sst::jucegui::data;
+
+struct SegmentedRatioEditor::DigitSource : jdat::Continuous
+{
+    SegmentedRatioEditor *parent;
+    int slot; // 0=t1 (integer), 1=t2 (hundredths), 2=t3 (hundred-thousandths)
+
+    DigitSource(SegmentedRatioEditor *p, int s) : parent(p), slot(s) {}
+
+    std::string getLabel() const override
+    {
+        switch (slot)
+        {
+        case 0:
+            return "Integer";
+        case 1:
+            return "10^-2";
+        case 2:
+            return "10^-4";
+        }
+        return "";
+    }
+
+    float getValue() const override
+    {
+        int t1, t2, t3;
+        parent->readDigits(t1, t2, t3);
+        if (slot == 0)
+            return static_cast<float>(t1);
+        if (slot == 1)
+            return static_cast<float>(t2);
+        return static_cast<float>(t3);
+    }
+
+    void setValueFromGUI(const float &f) override
+    {
+        int t1, t2, t3;
+        parent->readDigits(t1, t2, t3);
+        int v = static_cast<int>(std::round(f));
+        if (slot == 0)
+        {
+            // Skip 0 in the same direction as the jog buttons: dragging from a
+            // positive value down past 0 lands on -1; dragging a negative value
+            // up past 0 lands on +1. Without this, dragging through zero stalls
+            // because v=0 gets rebounded to the previous side.
+            if (v == 0)
+                v = (t1 > 0) ? -1 : 1;
+            t1 = std::clamp(v, static_cast<int>(getMin()), static_cast<int>(getMax()));
+        }
+        else if (slot == 1)
+        {
+            t2 = std::clamp(v, 0, 99);
+        }
+        else
+        {
+            t3 = std::clamp(v, 0, 99);
+        }
+        parent->writeDigits(t1, t2, t3);
+    }
+
+    void setValueFromModel(const float &) override {}
+
+    float getDefaultValue() const override
+    {
+        if (slot == 0)
+            return 1.f;
+        return 0.f;
+    }
+
+    float getMin() const override
+    {
+        if (slot == 0)
+        {
+            auto c = parent->continuous();
+            if (!c)
+                return -64.f;
+            auto minLog = c->getMin();
+            float mn = -1.f;
+            if (minLog < 0)
+                mn = -std::floor(std::pow(2.0, -minLog));
+            return mn;
+        }
+        return 0.f;
+    }
+
+    float getMax() const override
+    {
+        if (slot == 0)
+        {
+            auto c = parent->continuous();
+            if (!c)
+                return 64.f;
+            auto maxLog = c->getMax();
+            float mx = 1.f;
+            if (maxLog > 0)
+                mx = std::floor(std::pow(2.0, maxLog));
+            return mx;
+        }
+        if (slot == 1)
+            return 99.f;
+        return 99.f;
+    }
+
+    std::string getValueAsStringFor(float f) const override
+    {
+        int v = static_cast<int>(std::round(f));
+        if (slot == 0)
+            return std::to_string(v);
+        char buf[8];
+        std::snprintf(buf, sizeof(buf), "%02d", v);
+        return std::string(buf);
+    }
+
+    void setValueAsString(const std::string &s) override
+    {
+        if (s.empty())
+        {
+            setValueFromGUI(getDefaultValue());
+            return;
+        }
+        try
+        {
+            int v = std::stoi(s);
+            setValueFromGUI(static_cast<float>(v));
+        }
+        catch (...)
+        {
+            setValueFromGUI(getDefaultValue());
+        }
+    }
+};
+
+SegmentedRatioEditor::SegmentedRatioEditor()
+    : sst::jucegui::components::ContinuousParamEditor(
+          sst::jucegui::components::ContinuousParamEditor::Direction::HORIZONTAL)
+{
+}
+
+SegmentedRatioEditor::~SegmentedRatioEditor() = default;
+
+void SegmentedRatioEditor::decompose(float val, int &t1, int &t2, int &t3)
+{
+    int sign = (val < 0) ? -1 : 1;
+    double absVal = std::fabs(val);
+    double decimal = std::pow(2.0, absVal);
+    // Snap to the precision we display (X.XXXX) by going through integer space
+    // once, then doing the divmod with ints. Going through floating-point
+    // arithmetic for the divmod re-introduces drift: e.g. 24000.0 / 10000.0
+    // in IEEE double is 2.3999999999999999, so 2.4 → 2|39|99 with std::floor.
+    long long totalUnits = static_cast<long long>(std::llround(decimal * 10000.0));
+    if (totalUnits < 10000)
+        totalUnits = 10000; // can't represent below 1 in the integer slot
+    long long integer = totalUnits / 10000;
+    long long rem = totalUnits % 10000;
+
+    t1 = sign * static_cast<int>(integer);
+    t2 = static_cast<int>(rem / 100);
+    t3 = static_cast<int>(rem % 100);
+}
+
+float SegmentedRatioEditor::recompose(int t1, int t2, int t3) const
+{
+    if (t1 == 0)
+        t1 = 1;
+    int sign = (t1 < 0) ? -1 : 1;
+    double decimal = std::abs(t1) + t2 / 100.0 + t3 / 10000.0;
+    if (decimal < 1e-6)
+        decimal = 1e-6;
+    double val = sign * std::log2(decimal);
+    auto c = const_cast<SegmentedRatioEditor *>(this)->continuous();
+    if (c)
+        val = std::clamp(static_cast<float>(val), c->getMin(), c->getMax());
+    return static_cast<float>(val);
+}
+
+void SegmentedRatioEditor::readDigits(int &t1, int &t2, int &t3) const
+{
+    if (digitsValid)
+    {
+        t1 = cachedT1;
+        t2 = cachedT2;
+        t3 = cachedT3;
+        return;
+    }
+    auto c = const_cast<SegmentedRatioEditor *>(this)->continuous();
+    if (!c)
+    {
+        t1 = 1;
+        t2 = 0;
+        t3 = 0;
+        return;
+    }
+    decompose(c->getValue(), t1, t2, t3);
+    cachedT1 = t1;
+    cachedT2 = t2;
+    cachedT3 = t3;
+    digitsValid = true;
+}
+
+void SegmentedRatioEditor::writeDigits(int t1, int t2, int t3)
+{
+    auto c = continuous();
+    if (!c)
+        return;
+
+    // at the t1 extremes, t2/t3 must be 0 to stay within param min/max
+    int t1Min = static_cast<int>(slotSources[0]->getMin());
+    int t1Max = static_cast<int>(slotSources[0]->getMax());
+    if (t1 <= t1Min)
+    {
+        t1 = t1Min;
+        t2 = 0;
+        t3 = 0;
+    }
+    else if (t1 >= t1Max)
+    {
+        t1 = t1Max;
+        t2 = 0;
+        t3 = 0;
+    }
+
+    cachedT1 = t1;
+    cachedT2 = t2;
+    cachedT3 = t3;
+    digitsValid = true;
+    auto v = recompose(t1, t2, t3);
+    if (inOuterGesture)
+    {
+        // a slot widget already opened the gesture (drag); just set the value
+        c->setValueFromGUI(v);
+    }
+    else
+    {
+        // jog button or typein: wrap the write in its own atomic gesture
+        onBeginEdit();
+        c->setValueFromGUI(v);
+        onEndEdit();
+    }
+    for (auto &e : slotEditors)
+        if (e)
+            e->repaint();
+    repaint();
+}
+
+void SegmentedRatioEditor::jogSlot(int slot, bool up)
+{
+    int t1, t2, t3;
+    readDigits(t1, t2, t3);
+    int delta = up ? 1 : -1;
+    if (slot == 0)
+    {
+        if (t1 == 1 && !up)
+            t1 = -1;
+        else if (t1 == -1 && up)
+            t1 = 1;
+        else
+            t1 += delta;
+    }
+    else if (slot == 1)
+    {
+        t2 = std::clamp(t2 + delta, 0, 99);
+    }
+    else
+    {
+        t3 = std::clamp(t3 + delta, 0, 99);
+    }
+    writeDigits(t1, t2, t3);
+}
+
+void SegmentedRatioEditor::finalizeSetup()
+{
+    // seed cached digits from the current float so the UI starts coherent
+    digitsValid = false;
+    if (auto c = continuous())
+    {
+        decompose(c->getValue(), cachedT1, cachedT2, cachedT3);
+        digitsValid = true;
+    }
+
+    if (!slotSources[0])
+    {
+        for (int i = 0; i < numSlots; ++i)
+        {
+            slotSources[i] = std::make_unique<DigitSource>(this, i);
+
+            slotEditors[i] = std::make_unique<jcmp::DraggableTextEditableValue>();
+            slotEditors[i]->setSource(slotSources[i].get());
+            // Right-click on a slot routes to the parent's popup (the same one
+            // createComponent wired for the segmented editor as a whole), so the
+            // user gets the standard param menu wherever they click.
+            slotEditors[i]->onPopupMenu = [this](const juce::ModifierKeys &m)
+            {
+                if (onPopupMenu)
+                    onPopupMenu(m);
+            };
+            // Mark the outer gesture open BEFORE forwarding BEGIN, and clear it
+            // AFTER forwarding END, so writeDigits can suppress its inner pair
+            // for any sets that arrive between them (i.e. drag ticks).
+            slotEditors[i]->onBeginEdit = [this]()
+            {
+                inOuterGesture = true;
+                onBeginEdit();
+            };
+            slotEditors[i]->onEndEdit = [this]()
+            {
+                onEndEdit();
+                inOuterGesture = false;
+            };
+            addAndMakeVisible(*slotEditors[i]);
+
+            upButtons[i] = std::make_unique<jcmp::GlyphButton>(jcmp::GlyphPainter::JOG_UP);
+            upButtons[i]->setOnCallback([this, i]() { jogSlot(i, true); });
+            upButtons[i]->setLongHoldRepeats(true, 500, 100);
+            addAndMakeVisible(*upButtons[i]);
+
+            downButtons[i] = std::make_unique<jcmp::GlyphButton>(jcmp::GlyphPainter::JOG_DOWN);
+            downButtons[i]->setOnCallback([this, i]() { jogSlot(i, false); });
+            downButtons[i]->setLongHoldRepeats(true, 500, 100);
+            addAndMakeVisible(*downButtons[i]);
+        }
+    }
+    resized();
+    repaint();
+}
+
+void SegmentedRatioEditor::resized()
+{
+    if (!slotEditors[0])
+        return;
+    auto b = getLocalBounds();
+    auto cellW = b.getWidth() / numSlots;
+    int jogH = 11;
+    for (int i = 0; i < numSlots; ++i)
+    {
+        auto cell = juce::Rectangle<int>(b.getX() + i * cellW, b.getY(), cellW, b.getHeight());
+        upButtons[i]->setBounds(cell.removeFromTop(jogH).reduced(1));
+        downButtons[i]->setBounds(cell.removeFromBottom(jogH).reduced(1));
+        slotEditors[i]->setBounds(cell.reduced(1, 0));
+    }
+}
+
+void SegmentedRatioEditor::refreshFromExternal()
+{
+    digitsValid = false;
+    for (auto &e : slotEditors)
+        if (e)
+            e->repaint();
+    repaint();
+}
+
+} // namespace baconpaul::six_sines::ui

--- a/src/ui/segmented-ratio-editor.h
+++ b/src/ui/segmented-ratio-editor.h
@@ -1,0 +1,89 @@
+/*
+ * Six Sines
+ *
+ * A synth with audio rate modulation.
+ *
+ * Copyright 2024-2025, Paul Walker and Various authors, as described in the github
+ * transaction log.
+ *
+ * This source repo is released under the MIT license, but has
+ * GPL3 dependencies, as such the combined work will be
+ * released under GPL3.
+ *
+ * The source code and license are at https://github.com/baconpaul/six-sines
+ */
+
+#ifndef BACONPAUL_SIX_SINES_UI_SEGMENTED_RATIO_EDITOR_H
+#define BACONPAUL_SIX_SINES_UI_SEGMENTED_RATIO_EDITOR_H
+
+#include <array>
+#include <memory>
+#include <sst/jucegui/components/ContinuousParamEditor.h>
+#include <sst/jucegui/components/DraggableTextEditableValue.h>
+#include <sst/jucegui/components/GlyphButton.h>
+#include <sst/jucegui/data/Continuous.h>
+
+namespace baconpaul::six_sines::ui
+{
+struct SegmentedRatioEditor : sst::jucegui::components::ContinuousParamEditor
+{
+    static constexpr int numSlots = 3;
+
+    SegmentedRatioEditor();
+    ~SegmentedRatioEditor() override;
+
+    void paint(juce::Graphics &g) override {}
+    void resized() override;
+
+    // we delegate all real input to children, but right-click on the editor's
+    // own empty area should still raise the param popup menu.
+    void mouseDown(const juce::MouseEvent &e) override
+    {
+        if (e.mods.isPopupMenu() && onPopupMenu)
+            onPopupMenu(e.mods);
+    }
+    void mouseDrag(const juce::MouseEvent &) override {}
+    void mouseUp(const juce::MouseEvent &) override {}
+    void mouseDoubleClick(const juce::MouseEvent &) override {}
+
+    // invalidate cached digits and repaint slot widgets — call when the underlying
+    // value changed (automation, preset load, knob edit). PatchContinuous doesn't
+    // fan its data listeners on writes, so dataChanged() can't carry this for us
+    // and the SourcePanel routes external updates through this method directly.
+    void refreshFromExternal();
+
+    // call after createComponent has set the source
+    void finalizeSetup();
+
+    // decomposition: given underlying log2 value, get t1/t2/t3
+    static void decompose(float val, int &t1, int &t2, int &t3);
+    // recomposition: given t1/t2/t3, return clamped underlying log2 value
+    float recompose(int t1, int t2, int t3) const;
+
+    // read the current digits — returns cached ints when the UI authored the
+    // current float; otherwise decomposes from the float.
+    void readDigits(int &t1, int &t2, int &t3) const;
+    // write digits back through the main source (with begin/end edit)
+    void writeDigits(int t1, int t2, int t3);
+
+    void jogSlot(int slot, bool up);
+
+    // cached digits — UI-owned representation that survives float roundtrip
+    mutable int cachedT1{1}, cachedT2{0}, cachedT3{0};
+    mutable bool digitsValid{false};
+
+    // Set by the slot widgets' begin/end-edit hooks while a drag gesture is open.
+    // While true, writeDigits skips its own BEGIN/END pair so we don't nest
+    // gestures within the slot widget's outer one.
+    bool inOuterGesture{false};
+
+    struct DigitSource;
+    std::array<std::unique_ptr<DigitSource>, numSlots> slotSources;
+    std::array<std::unique_ptr<sst::jucegui::components::DraggableTextEditableValue>, numSlots>
+        slotEditors;
+    std::array<std::unique_ptr<sst::jucegui::components::GlyphButton>, numSlots> upButtons,
+        downButtons;
+};
+} // namespace baconpaul::six_sines::ui
+
+#endif

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -115,6 +115,21 @@ SixSinesEditor::SixSinesEditor(Synth::audioToUIQueue_t &atou, Synth::mainToAudio
 {
     setTitle("Six Sines - an Audio Rate Modulation Synthesizer");
     setAccessible(true);
+
+    // Some panels use defaults on construction
+    presetManager = std::make_unique<presets::PresetManager>(clapHost);
+    presetManager->onPresetLoaded = [this](auto s)
+    {
+        this->postPatchChange(s);
+        repaint();
+    };
+
+    uiThemeManager = std::make_unique<presets::UIThemeManager>();
+
+    defaultsProvider = std::make_unique<defaultsProvder_t>(
+        presetManager->userPath, "SixSinesUI", defaultName,
+        [](auto e, auto b) { SXSNLOG("[ERROR]" << e << " " << b); });
+
     sst::jucegui::style::StyleSheet::initializeStyleSheets([]() {});
 
     sheet_t::addClass(PatchMenu).withBaseClass(jcmp::JogUpDownButton::Styles::styleClass);
@@ -215,14 +230,6 @@ SixSinesEditor::SixSinesEditor(Synth::audioToUIQueue_t &atou, Synth::mainToAudio
     toolTip = std::make_unique<jcmp::ToolTip>();
     addChildComponent(*toolTip);
 
-    presetManager = std::make_unique<presets::PresetManager>(clapHost);
-    uiThemeManager = std::make_unique<presets::UIThemeManager>();
-    presetManager->onPresetLoaded = [this](auto s)
-    {
-        this->postPatchChange(s);
-        repaint();
-    };
-
     presetDataBinding = std::make_unique<PresetDataBinding>(*presetManager, patchCopy, mainToAudio);
     presetDataBinding->setStateForDisplayName(patchCopy.name);
 
@@ -234,9 +241,6 @@ SixSinesEditor::SixSinesEditor(Synth::audioToUIQueue_t &atou, Synth::mainToAudio
     setPatchNameDisplay();
     sst::jucegui::component_adapters::setTraversalId(presetButton.get(), 174);
 
-    defaultsProvider = std::make_unique<defaultsProvder_t>(
-        presetManager->userPath, "SixSinesUI", defaultName,
-        [](auto e, auto b) { SXSNLOG("[ERROR]" << e << " " << b); });
     // initializeBaseSkin() calls applyToStylesheet and guards lnf->setStyle with
     // "if (lnf)" — lnf is null at this point so that guard is a no-op.  lnf is
     // created immediately after and explicitly calls setStyle, which is correct.

--- a/src/ui/source-panel.cpp
+++ b/src/ui/source-panel.cpp
@@ -16,6 +16,7 @@
 #include "sst/jucegui/components/ToggleButton.h"
 #include "source-panel.h"
 #include "source-sub-panel.h"
+#include "segmented-ratio-editor.h"
 #include "ui-constants.h"
 #include "dsp/sintable.h"
 #include "sst/jucegui/accessibility/KeyboardTraverser.h"
@@ -26,7 +27,6 @@ namespace baconpaul::six_sines::ui
 {
 SourcePanel::SourcePanel(SixSinesEditor &e) : jcmp::NamedPanel("Source"), HasEditor(e)
 {
-    using kt_t = sst::jucegui::accessibility::KeyboardTraverser;
     auto &mn = editor.patchCopy.sourceNodes;
     for (auto i = 0U; i < numOps; ++i)
     {
@@ -70,10 +70,67 @@ SourcePanel::SourcePanel(SixSinesEditor &e) : jcmp::NamedPanel("Source"), HasEdi
         sst::jucegui::component_adapters::setTraversalId(downButton[i].get(), i * 5 + 20);
         sst::jucegui::component_adapters::setTraversalId(upButton[i].get(), i * 5 + 20);
         sst::jucegui::component_adapters::setTraversalId(knobs[i].get(), i * 5 + 21);
+
+        // Build the segmented editor eagerly. Both knob and segmented are bound to the
+        // ratio param at all times; we only swap visibility when the editor type changes.
+        createComponent(editor, *this, mn[i].ratio, segmentedEditors[i], segmentedEditorsData[i],
+                        i);
+        segmentedEditors[i]->finalizeSetup();
+        addChildComponent(*segmentedEditors[i]);
+
+        // The second createComponent above clobbered componentByID[ratioId]; restore it
+        // to the knob (the popup-menu/accessibility default), then register a refresh
+        // hook that fans inbound updates out to BOTH widgets so neither goes stale.
+        auto id = mn[i].ratio.meta.id;
+        editor.componentByID[id] = juce::Component::SafePointer<juce::Component>(knobs[i].get());
+        editor.componentRefreshByID[id] =
+            [kw = juce::Component::SafePointer<juce::Component>(knobs[i].get()),
+             sw = juce::Component::SafePointer<SegmentedRatioEditor>(segmentedEditors[i].get())]()
+        {
+            if (kw)
+                kw->repaint();
+            if (sw)
+                sw->refreshFromExternal();
+        };
+
+        // When the knob writes the ratio, force the segmented editor to re-decompose
+        // from the new float — PatchContinuous doesn't fire data listeners on its own.
+        knobsData[i]->onGuiSetValue =
+            [sw = juce::Component::SafePointer<SegmentedRatioEditor>(segmentedEditors[i].get())]()
+        {
+            if (sw)
+                sw->refreshFromExternal();
+        };
+
+        // The segmented editor has its own PatchContinuous binding (built by the
+        // second createComponent above). Right-click → popup-menu typein writes
+        // through that binding, which also bypasses data listeners; reseed the
+        // cached digits the same way.
+        segmentedEditorsData[i]->onGuiSetValue =
+            [sw = juce::Component::SafePointer<SegmentedRatioEditor>(segmentedEditors[i].get())]()
+        {
+            if (sw)
+                sw->refreshFromExternal();
+        };
     }
 
     highlight = std::make_unique<KnobHighlight>(editor);
     addChildComponent(*highlight);
+
+    hasHamburger = true;
+    onHamburger = [w = juce::Component::SafePointer(this)]()
+    {
+        if (w)
+            w->showHamburgerMenu();
+    };
+
+    auto stored = editor.defaultsProvider->getUserDefaultValue(Defaults::sourceEditorType,
+                                                               static_cast<int>(SourceEditor_Knob));
+    // Sanitize: if the persisted value isn't one of the editor types we know about
+    // (e.g. left over from an earlier build with extra enumerators), fall back to Knob.
+    if (stored != SourceEditor_Knob && stored != SourceEditor_SegmentedDecimal)
+        stored = SourceEditor_Knob;
+    setEditorType(static_cast<SourceEditorType>(stored), false);
 }
 SourcePanel::~SourcePanel() = default;
 
@@ -84,14 +141,74 @@ void SourcePanel::resized()
     auto y = b.getY();
     for (auto i = 0U; i < numOps; ++i)
     {
-        positionPowerKnobSwitchAndLabel(x, y, power[i], upButton[i], knobs[i], labels[i]);
-        auto b = upButton[i]->getBounds().reduced(2, 0).translated(0, -2);
-        auto ub = b.withTrimmedLeft(b.getWidth() / 2).withTrimmedBottom(uicMargin / 2);
-        auto db = b.withTrimmedRight(b.getWidth() / 2).withTrimmedBottom(uicMargin / 2);
-        upButton[i]->setBounds(ub);
-        downButton[i]->setBounds(db);
+        if (editorType == SourceEditor_Knob)
+        {
+            positionPowerKnobSwitchAndLabel(x, y, power[i], upButton[i], knobs[i], labels[i]);
+            auto b = upButton[i]->getBounds().reduced(2, 0).translated(0, -2);
+            auto ub = b.withTrimmedLeft(b.getWidth() / 2).withTrimmedBottom(uicMargin / 2);
+            auto db = b.withTrimmedRight(b.getWidth() / 2).withTrimmedBottom(uicMargin / 2);
+            upButton[i]->setBounds(ub);
+            downButton[i]->setBounds(db);
+        }
+        else
+        {
+            // editor takes the full cell width above the label row;
+            // power button sits in the label row on the left, label to its right
+            auto cell = juce::Rectangle<int>(x, y, uicPowerKnobWidth, uicKnobSize);
+            segmentedEditors[i]->setBounds(cell);
+
+            auto labelRow = juce::Rectangle<int>(x, y + uicKnobSize + uicLabelGap,
+                                                 uicPowerKnobWidth, uicLabelHeight);
+            power[i]->setBounds(labelRow.withWidth(uicLabelHeight).reduced(2));
+            labels[i]->setBounds(labelRow.withTrimmedLeft(uicLabelHeight + uicMargin));
+        }
         x += uicPowerKnobWidth + uicMargin;
     }
+}
+
+void SourcePanel::setEditorType(SourceEditorType t, bool persist)
+{
+    editorType = t;
+
+    for (auto i = 0U; i < numOps; ++i)
+    {
+        bool isKnob = (t == SourceEditor_Knob);
+        bool isSeg = (t == SourceEditor_SegmentedDecimal);
+        knobs[i]->setVisible(isKnob);
+        upButton[i]->setVisible(isKnob);
+        downButton[i]->setVisible(isKnob);
+        segmentedEditors[i]->setVisible(isSeg);
+        labels[i]->setText(isKnob ? ("Op " + std::to_string(i + 1) + " Ratio")
+                                  : ("Op " + std::to_string(i + 1)));
+
+        updateOpEnabledState(i);
+    }
+
+    if (persist)
+        editor.defaultsProvider->updateUserDefaultValue(Defaults::sourceEditorType,
+                                                        static_cast<int>(t));
+
+    resized();
+    repaint();
+}
+
+void SourcePanel::showHamburgerMenu()
+{
+    juce::PopupMenu p;
+    p.addSectionHeader("Source Editor");
+    p.addSeparator();
+    auto add = [this, &p](const juce::String &name, SourceEditorType t)
+    {
+        p.addItem(name, true, editorType == t,
+                  [w = juce::Component::SafePointer(this), t]()
+                  {
+                      if (w)
+                          w->setEditorType(t, true);
+                  });
+    };
+    add("Knob", SourceEditor_Knob);
+    add("Segmented", SourceEditor_SegmentedDecimal);
+    p.showMenuAsync(juce::PopupMenu::Options().withParentComponent(&editor));
 }
 
 void SourcePanel::mouseDown(const juce::MouseEvent &e)
@@ -99,6 +216,11 @@ void SourcePanel::mouseDown(const juce::MouseEvent &e)
     if (e.mods.isPopupMenu())
     {
         editor.showNavigationMenu();
+        return;
+    }
+    if (hasHamburger && getHamburgerRegion().contains(e.position.toInt()))
+    {
+        jcmp::NamedPanel::mouseDown(e);
         return;
     }
     for (int i = 0; i < numOps; ++i)
@@ -192,6 +314,7 @@ void SourcePanel::updateOpEnabledState(int idx)
     knobs[idx]->setEnabled(!isAudioIn);
     upButton[idx]->setEnabled(!isAudioIn);
     downButton[idx]->setEnabled(!isAudioIn);
+    segmentedEditors[idx]->setEnabled(!isAudioIn);
 }
 
 } // namespace baconpaul::six_sines::ui

--- a/src/ui/source-panel.h
+++ b/src/ui/source-panel.h
@@ -20,9 +20,12 @@
 #include <sst/jucegui/components/GlyphButton.h>
 #include "six-sines-editor.h"
 #include "patch-data-bindings.h"
+#include "ui-defaults.h"
 
 namespace baconpaul::six_sines::ui
 {
+struct SegmentedRatioEditor;
+
 struct SourcePanel : jcmp::NamedPanel, HasEditor
 {
     SourcePanel(SixSinesEditor &);
@@ -48,6 +51,13 @@ struct SourcePanel : jcmp::NamedPanel, HasEditor
     std::array<std::unique_ptr<jcmp::Label>, numOps> labels;
     std::array<std::unique_ptr<PatchDiscrete>, numOps> powerData;
     std::array<std::unique_ptr<jcmp::GlyphButton>, numOps> upButton, downButton;
+
+    std::array<std::unique_ptr<SegmentedRatioEditor>, numOps> segmentedEditors;
+    std::array<std::unique_ptr<PatchContinuous>, numOps> segmentedEditorsData;
+
+    SourceEditorType editorType{SourceEditor_Knob};
+    void setEditorType(SourceEditorType t, bool persist);
+    void showHamburgerMenu();
 
     void adjustRatio(int idx, bool up);
     void updateOpEnabledState(int idx);

--- a/src/ui/ui-defaults.h
+++ b/src/ui/ui-defaults.h
@@ -33,7 +33,14 @@ enum Defaults
     defaultAuthor,
     spectrumAnalysisMode,
     spectrumScopeScale,
+    sourceEditorType,
     numDefaults
+};
+
+enum SourceEditorType : int
+{
+    SourceEditor_Knob = 0,
+    SourceEditor_SegmentedDecimal = 1
 };
 
 inline std::string defaultName(Defaults d)
@@ -58,6 +65,8 @@ inline std::string defaultName(Defaults d)
         return "spectrumAnalysisMode";
     case spectrumScopeScale:
         return "spectrumScopeScale";
+    case sourceEditorType:
+        return "sourceEditorType";
     case numDefaults:
     {
         SXSNLOG("Software Error - defaults found");


### PR DESCRIPTION
The source panel now offers two ratio editors: the existing knob and a new segmented decimal editor that breaks the ratio into integer, hundredths, and hundred-thousandths digits with jog, drag, and typein. Selection is via a hamburger menu on the panel and persisted as a user default. Sub-harmonics are signaled by a negative integer; the displayed digits stay stable across the log2 / float roundtrip via a UI-side cache.

Both editors are constructed eagerly and stay in sync — automation, preset load, knob edit, and popup-menu writes all reseed the segmented cache so neither widget goes stale.

Bumps sst-jucegui for the long-hold auto-repeat support used by the segmented editor's jog buttons.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>