### PR TITLE
Small UI fixes and changes

### DIFF
--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -166,10 +166,10 @@ void Synth::setSampleRate(double sampleRate)
     monoValues.sr.setSampleRate(internalRate);
 
     lagHandler.setRate(60, blockSize, monoValues.sr.sampleRate);
-    vuPeak.setSampleRate(monoValues.sr.sampleRate);
+    vuPeak.setSampleRate(monoValues.sr.sampleRate, 20);
     for (int i = 0; i < numOps; ++i)
     {
-        opVuPeak[i].setSampleRate(monoValues.sr.sampleRate);
+        opVuPeak[i].setSampleRate(monoValues.sr.sampleRate, 20);
     }
     sampleRateRatio = hostSampleRate / engineSampleRate;
 

--- a/src/ui/macro-panel.cpp
+++ b/src/ui/macro-panel.cpp
@@ -39,6 +39,15 @@ MacroPanel::MacroPanel(SixSinesEditor &e) : jcmp::NamedPanel("Macros"), HasEdito
         createComponent(editor, *this, mn[i].macroPower, power[i], powerD[i], i);
         power[i]->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::GLYPH);
         power[i]->setGlyph(sst::jucegui::components::GlyphPainter::POWER);
+        // The toggle's onBeginEdit calls beginEdit(i) → setSelectedIndex →
+        // setEnabledState before setValueFromGUI flips macroPower, so the sub-panel
+        // would latch the stale value. Re-run setEnabledState after the GUI write.
+        powerD[i]->onGuiSetValue = [this, i]()
+        {
+            if (editor.macroSubPanel && editor.macroSubPanel->isVisible() &&
+                editor.macroSubPanel->index == i)
+                editor.macroSubPanel->setEnabledState();
+        };
         addAndMakeVisible(*power[i]);
     }
 

--- a/src/ui/macro-sub-panel.cpp
+++ b/src/ui/macro-sub-panel.cpp
@@ -108,6 +108,7 @@ void MacroSubPanel::setSelectedIndex(size_t i)
             w->setEnabledState();
     };
     editor.componentRefreshByID[mn.envIsMultiplcative.meta.id] = refreshEnabled;
+    editor.componentRefreshByID[mn.macroPower.meta.id] = refreshEnabled;
     envMulD->onGuiSetValue = refreshEnabled;
 
     auto &nameBuf = editor.patchCopy.macroNames[i];

--- a/src/ui/playmode-sub-panel.cpp
+++ b/src/ui/playmode-sub-panel.cpp
@@ -184,6 +184,10 @@ PlayModeSubPanel::PlayModeSubPanel(SixSinesEditor &e) : HasEditor(e)
     addAndMakeVisible(*panicButton);
     addAndMakeVisible(*panicTitle);
 
+    outputControlTitle = std::make_unique<jcmp::RuledLabel>();
+    outputControlTitle->setText("Output Control");
+    addAndMakeVisible(*outputControlTitle);
+
     createComponent(editor, *this, editor.patchCopy.output.sampleRateStrategy, srStrat, srStratD);
     addAndMakeVisible(*srStrat);
     createComponent(editor, *this, editor.patchCopy.output.resampleEngine, rsEng, rsEngD);
@@ -199,61 +203,67 @@ void PlayModeSubPanel::resized()
 {
     namespace jlo = sst::jucegui::layouts;
     auto skinny = uicKnobSize + 30;
-    auto playRowHeight =
-        uicTitleLabelInnerBox + 2 * uicLabelHeight + uicMargin + 5 * uicLabelHeight + 6 * uicMargin;
 
-    auto outer = jlo::HList().at(uicMargin, 0).withAutoGap(2 * uicMargin);
+    // Top section: 4 columns, each split into a top sub-section and a bottom sub-section
+    //   col1: Voices / Unison
+    //   col2: Play (mode + triggers + porta)
+    //   col3: Bend / Octave
+    //   col4: MPE / Panic
+    // The two tallest columns (1 and 2) drive the row height.
+    auto topRowHeight = uicTitleLabelInnerBox + 7 * uicLabelHeight + 7 * uicMargin;
 
-    // Column 1: voices / bend / octave / mpe / panic
+    auto outer = jlo::VList().at(uicMargin, 0).withAutoGap(2 * uicMargin);
+
+    auto topRow = jlo::HList().withHeight(topRowHeight).withAutoGap(2 * uicMargin);
+
     auto col1 = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
     col1.add(titleLabelGaplessLayout(voiceLimitL));
     col1.add(jlo::Component(*voiceLimit).withHeight(uicLabelHeight));
-    col1.add(titleLabelGaplessLayout(bendTitle));
-    col1.add(sideLabel(bUpL, bUp));
-    col1.add(sideLabel(bDnL, bDn));
-    col1.add(titleLabelGaplessLayout(tsposeTitle));
-    col1.add(jlo::Component(*tsposeButton).withHeight(uicLabelHeight));
-    col1.add(titleLabelGaplessLayout(mpeTitle));
-    col1.add(jlo::Component(*mpeActiveButton).withHeight(uicLabelHeight));
-    col1.add(jlo::Component(*mpeRange).withHeight(uicLabelHeight));
-    col1.add(jlo::Component(*mpeRangeL).withHeight(uicLabelHeight));
-    col1.add(titleLabelGaplessLayout(panicTitle));
-    col1.add(jlo::Component(*panicButton).withHeight(uicLabelHeight));
-    outer.add(col1);
+    col1.add(titleLabelGaplessLayout(uniTitle));
+    col1.add(jlo::Component(*uniCt).withHeight(uicLabelHeight));
+    col1.add(jlo::Component(*uniCtL).withHeight(uicLabelHeight));
+    col1.add(jlo::Component(*uniRPhase).withHeight(uicLabelHeight));
+    col1.add(sideLabelSlider(uniSpreadG, uniSpread));
+    col1.add(sideLabelSlider(uniPanG, uniPan));
+    topRow.add(col1);
 
-    // Column 2: play + unison on top, oversampling below
-    auto col2 = jlo::VList().withWidth(2 * skinny + 2 * uicMargin).withAutoGap(2 * uicMargin);
+    auto col2 = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
+    col2.add(titleLabelGaplessLayout(playTitle));
+    col2.add(jlo::Component(*playMode).withHeight(2 * uicLabelHeight + uicMargin));
+    col2.add(jlo::Component(*triggerButton).withHeight(uicLabelHeight));
+    col2.add(jlo::Component(*pianoModeButton).withHeight(uicLabelHeight));
+    col2.add(jlo::Component(*portaL).withHeight(uicLabelHeight));
+    col2.add(jlo::Component(*portaTime).withHeight(uicLabelHeight).insetBy(0, 2));
+    col2.add(jlo::Component(*portaContinuationButton).withHeight(uicLabelHeight));
+    topRow.add(col2);
 
-    auto topRow = jlo::HList().withHeight(playRowHeight).withAutoGap(2 * uicMargin);
+    auto col3 = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
+    col3.add(titleLabelGaplessLayout(bendTitle));
+    col3.add(sideLabel(bUpL, bUp));
+    col3.add(sideLabel(bDnL, bDn));
+    col3.add(titleLabelGaplessLayout(tsposeTitle));
+    col3.add(jlo::Component(*tsposeButton).withHeight(uicLabelHeight));
+    topRow.add(col3);
 
-    auto pml = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
-    pml.add(titleLabelGaplessLayout(playTitle));
-    pml.add(jlo::Component(*playMode).withHeight(2 * uicLabelHeight + uicMargin));
-    pml.add(jlo::Component(*triggerButton).withHeight(uicLabelHeight));
-    pml.add(jlo::Component(*pianoModeButton).withHeight(uicLabelHeight));
-    pml.add(jlo::Component(*portaL).withHeight(uicLabelHeight));
-    pml.add(jlo::Component(*portaTime).withHeight(uicLabelHeight).insetBy(0, 2));
-    pml.add(jlo::Component(*portaContinuationButton).withHeight(uicLabelHeight));
-    topRow.add(pml);
+    auto col4 = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
+    col4.add(titleLabelGaplessLayout(mpeTitle));
+    col4.add(jlo::Component(*mpeActiveButton).withHeight(uicLabelHeight));
+    col4.add(jlo::Component(*mpeRange).withHeight(uicLabelHeight));
+    col4.add(jlo::Component(*mpeRangeL).withHeight(uicLabelHeight));
+    col4.add(titleLabelGaplessLayout(panicTitle));
+    col4.add(jlo::Component(*panicButton).withHeight(uicLabelHeight));
+    topRow.add(col4);
 
-    auto uml = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
-    uml.add(titleLabelGaplessLayout(uniTitle));
-    uml.add(jlo::Component(*uniCt).withHeight(uicLabelHeight));
-    uml.add(jlo::Component(*uniCtL).withHeight(uicLabelHeight));
-    uml.add(jlo::Component(*uniRPhase).withHeight(uicLabelHeight));
-    uml.add(sideLabelSlider(uniSpreadG, uniSpread));
-    uml.add(sideLabelSlider(uniPanG, uniPan));
-    topRow.add(uml);
+    outer.add(topRow);
 
-    col2.add(topRow);
+    auto bottomWidth = 4 * skinny + 3 * 2 * uicMargin;
+    outer.add(titleLabelGaplessLayout(outputControlTitle).withWidth(bottomWidth));
 
-    auto rsl = jlo::VList().withAutoGap(uicMargin);
+    auto rsl = jlo::VList().withWidth(bottomWidth).withAutoGap(uicMargin);
     rsl.add(titleLabelGaplessLayout(srStratLab));
     rsl.add(jlo::Component(*srStrat).withHeight(uicLabelHeight));
     rsl.add(jlo::Component(*rsEng).withHeight(uicLabelHeight));
-    col2.add(rsl);
-
-    outer.add(col2);
+    outer.add(rsl);
 
     outer.doLayout();
 }

--- a/src/ui/playmode-sub-panel.h
+++ b/src/ui/playmode-sub-panel.h
@@ -85,6 +85,8 @@ struct PlayModeSubPanel : juce::Component, HasEditor
 
     std::unique_ptr<jcmp::TextPushButton> panicButton;
 
+    std::unique_ptr<jcmp::RuledLabel> outputControlTitle;
+
     std::unique_ptr<jcmp::RuledLabel> srStratLab;
     std::unique_ptr<jcmp::JogUpDownButton> srStrat;
     std::unique_ptr<PatchDiscrete> srStratD;

--- a/src/ui/segmented-ratio-editor.cpp
+++ b/src/ui/segmented-ratio-editor.cpp
@@ -422,10 +422,6 @@ void SegmentedRatioEditor::writeDigits(int t1, int t2, int t3)
         t3 = 0;
     }
 
-    cachedT1 = t1;
-    cachedT2 = t2;
-    cachedT3 = t3;
-    digitsValid = true;
     auto v = recompose(t1, t2, t3);
     if (inOuterGesture)
     {
@@ -439,6 +435,14 @@ void SegmentedRatioEditor::writeDigits(int t1, int t2, int t3)
         c->setValueFromGUI(v);
         onEndEdit();
     }
+    // Restore the cache after setValueFromGUI: the panel wires onGuiSetValue →
+    // refreshFromExternal, which invalidates digits. +1 and -1 both encode to
+    // log2(1)=0 in the float, so decompose can't tell them apart; the cache is
+    // the only thing that keeps the sign at that boundary.
+    cachedT1 = t1;
+    cachedT2 = t2;
+    cachedT3 = t3;
+    digitsValid = true;
     if (editor)
         editor->repaint();
     repaint();


### PR DESCRIPTION
- Settings panel: reorganize the top into a 4-column grid (Voices/Unison, Play/Porta, Bend/Octave, MPE/Panic) and add an Output Control divider above the Oversampling controls
- Macro power: refresh the macro sub-panel's enabled state after the power toggle writes its new value, so the ADSR/LFO/mod widgets no longer latch the stale (pre-toggle) state
- Ratio editor: preserve the +1/-1 sign across a write — the cache now survives setValueFromGUI's external-refresh callback, so jogging down from 1 lands on -1 and jogging up from -2 lands on -1
- Bump sst-basic-blocks and pass the new VU peak LPF frequency

Assisted-by: Claude Opus 4.7