### PR TITLE
Add CZ-style resonant sweep extended mode

### DIFF
--- a/doc/12_roadmap.md
+++ b/doc/12_roadmap.md
@@ -16,6 +16,7 @@ I have a lot of ideas for a '1.2' version of six sines. Not 2.0. Still compatibl
   - Add a cytomic SVF at 16khz / root 2 resonance
   - ZOH decimate the signal to 32khz at upper rate
   - Do a bitheight redicution (round(f * (1<<b)) / (1<<b))
+  - Add an optional highpass at 5-15hz to kill DC
   - Downsample with strategy
 - Each of those steps except the first and last is optional.
 - basically all options to make it less 'clean' which all toggle at internal block
@@ -26,18 +27,16 @@ I have a lot of ideas for a '1.2' version of six sines. Not 2.0. Still compatibl
 - that crazy idea kisney and i chatted about
 - more t/k
 
-## UI Ratio editor Upgrade
-
-The ratio editor is a knob. That's clumsy. segmented control will be better. 
-Want modes - like segmented float, ratio as pair of ints, etc...
-Some of those modes like ratio as pair of ints requires extra streaming to store and retain
-Probably want a legacy mode of knob
-
 ## Infrastructure
 
 - Clap Wrapper Standalone upgrades
   - windows ui open isn't right
   - jack on linux
+
+## UI Ratio editor Upgrade **DONE**
+
+The ratio editor is a knob. That's clumsy. segmented control will be better.
+Want modes - like segmented float, 
 
 ## Visualization **DONE**
 

--- a/src/dsp/op_source.h
+++ b/src/dsp/op_source.h
@@ -27,6 +27,7 @@
 #include "synth/mono_values.h"
 #include "synth/voice_values.h"
 #include "remap_functions.h"
+#include "resonant_window.h"
 
 namespace baconpaul::six_sines
 {
@@ -84,6 +85,28 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
         lfoResetMod();
 
         st.setSampleRate(monoValues.sr.sampleRate);
+        stWindow.setSampleRate(monoValues.sr.sampleRate);
+        // Pick the table for the resonant-sweep window. BLACKMAN_HARRIS and TUKEY pull
+        // their own tables; everything else (closed-form windows + HANN) defaults to
+        // HANN so a mid-note shape change doesn't read a stale unrelated table — the
+        // closed-form arms in the inner loop don't read stWindow at all.
+        {
+            using RW = Patch::SourceNode::ResonantSweepWindow;
+            auto rw = static_cast<RW>(
+                static_cast<uint32_t>(std::round(sourceNode.resonantSweepWindowShape.value)));
+            switch (rw)
+            {
+            case RW::BLACKMAN_HARRIS:
+                stWindow.setWaveForm(SinTable::BLACKMAN_HARRIS_WINDOW);
+                break;
+            case RW::TUKEY:
+                stWindow.setWaveForm(SinTable::TUKEY_WINDOW);
+                break;
+            default:
+                stWindow.setWaveForm(SinTable::HANN_WINDOW);
+                break;
+            }
+        }
         firstTime = true;
         extendedMPrior = sourceNode.extendedModeM.value;
         // Configure the M/N lags only if the operator is actually using an extended mode
@@ -92,12 +115,12 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
             using EM = Patch::SourceNode::ExtendedMode;
             auto em = static_cast<EM>(
                 static_cast<uint32_t>(std::round(sourceNode.extendedModeMode.value)));
-            if (em == EM::PHASE_REMAP)
+            if (em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP)
             {
                 extendedLagM.setRateInMilliseconds(10, monoValues.sr.samplerate, blockSizeInv);
                 extendedLagM.snapTo(sourceNode.extendedModeM.value);
-                // N is unused in PHASE_REMAP — leave its lag uninitialized until a future
-                // mode that consumes N is added.
+                // N is unused in PHASE_REMAP / RESONANT_SWEEP — leave its lag uninitialized
+                // until a future mode that consumes N is added.
             }
         }
         zeroInputs();
@@ -168,7 +191,7 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
         using EM = Patch::SourceNode::ExtendedMode;
         auto em =
             static_cast<EM>(static_cast<uint32_t>(std::round(sourceNode.extendedModeMode.value)));
-        if (em == EM::PHASE_REMAP)
+        if (em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP)
             used = used || (sourceNode.lfoToExtendedModeM.value != 0);
 
         return used;
@@ -363,9 +386,60 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
             break;
         }
         case EM::RESONANT_SWEEP:
-            // coming soon — falls through to the no-extension path for now
-            innerLoopImpl<EM::NONE>(onto, fbv, rf, dRF, phs);
+        {
+            using RW = Patch::SourceNode::ResonantSweepWindow;
+            using RFD = Patch::SourceNode::ResonantSweepFrequencyDepth;
+            auto rw = static_cast<RW>(
+                static_cast<uint32_t>(std::round(sourceNode.resonantSweepWindowShape.value)));
+            auto rfd = static_cast<RFD>(
+                static_cast<uint32_t>(std::round(sourceNode.resonantSweepFrequencyDepth.value)));
+            float kScale = 4.0f;
+            switch (rfd)
+            {
+            case RFD::TWO:
+                kScale = 2.0f;
+                break;
+            case RFD::FOUR:
+                kScale = 4.0f;
+                break;
+            case RFD::TEN:
+                kScale = 10.0f;
+                break;
+            }
+            // The PhaseMapShape template arg is unused on this branch; leave it at default.
+            switch (rw)
+            {
+            case RW::SAW:
+                innerLoopImpl<EM::RESONANT_SWEEP, Patch::SourceNode::PhaseMapShape::SAW, RW::SAW>(
+                    onto, fbv, rf, dRF, phs, kScale);
+                break;
+            case RW::TRIANGLE:
+                innerLoopImpl<EM::RESONANT_SWEEP, Patch::SourceNode::PhaseMapShape::SAW,
+                              RW::TRIANGLE>(onto, fbv, rf, dRF, phs, kScale);
+                break;
+            case RW::TRAPEZOID:
+                innerLoopImpl<EM::RESONANT_SWEEP, Patch::SourceNode::PhaseMapShape::SAW,
+                              RW::TRAPEZOID>(onto, fbv, rf, dRF, phs, kScale);
+                break;
+            case RW::FULLTRAP:
+                innerLoopImpl<EM::RESONANT_SWEEP, Patch::SourceNode::PhaseMapShape::SAW,
+                              RW::FULLTRAP>(onto, fbv, rf, dRF, phs, kScale);
+                break;
+            case RW::HANN:
+                innerLoopImpl<EM::RESONANT_SWEEP, Patch::SourceNode::PhaseMapShape::SAW, RW::HANN>(
+                    onto, fbv, rf, dRF, phs, kScale);
+                break;
+            case RW::BLACKMAN_HARRIS:
+                innerLoopImpl<EM::RESONANT_SWEEP, Patch::SourceNode::PhaseMapShape::SAW,
+                              RW::BLACKMAN_HARRIS>(onto, fbv, rf, dRF, phs, kScale);
+                break;
+            case RW::TUKEY:
+                innerLoopImpl<EM::RESONANT_SWEEP, Patch::SourceNode::PhaseMapShape::SAW, RW::TUKEY>(
+                    onto, fbv, rf, dRF, phs, kScale);
+                break;
+            }
             break;
+        }
         case EM::REDACTED_1:
             // coming soon — falls through to the no-extension path for now
             innerLoopImpl<EM::NONE>(onto, fbv, rf, dRF, phs);
@@ -373,13 +447,16 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
         }
     }
 
-    template <Patch::SourceNode::ExtendedMode ET,
-              Patch::SourceNode::PhaseMapShape S = Patch::SourceNode::PhaseMapShape::SAW>
-    void innerLoopImpl(float *onto, float *fbv, float rf, const float dRF, uint32_t &phs)
+    template <
+        Patch::SourceNode::ExtendedMode ET,
+        Patch::SourceNode::PhaseMapShape S = Patch::SourceNode::PhaseMapShape::SAW,
+        Patch::SourceNode::ResonantSweepWindow R = Patch::SourceNode::ResonantSweepWindow::SAW>
+    void innerLoopImpl(float *onto, float *fbv, float rf, const float dRF, uint32_t &phs,
+                       float kScale = 1.0f)
     {
         using EM = Patch::SourceNode::ExtendedMode;
         float nextM{0.f}, dM{0.f};
-        if constexpr (ET == EM::PHASE_REMAP)
+        if constexpr (ET == EM::PHASE_REMAP || ET == EM::RESONANT_SWEEP)
         {
             // Raw target m for this block: patch value + external mod + env / lfo contributions.
             auto lfoFac = *lfoFacP;
@@ -412,6 +489,7 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
 
             auto ph = phs + phaseInput[i] + (int32_t)(feedbackLevel[i] * fb);
 
+            float out;
             if constexpr (ET == EM::PHASE_REMAP)
             {
                 using PM = Patch::SourceNode::PhaseMapShape;
@@ -428,9 +506,35 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
                 else if constexpr (S == PM::DOUBLE_SAW)
                     ph = remap::remapDoubleSaw(ph & phase::phaseMask, nextM);
                 nextM += dM;
+                out = st.at(ph);
             }
-
-            auto out = st.at(ph);
+            else if constexpr (ET == EM::RESONANT_SWEEP)
+            {
+                using RW = Patch::SourceNode::ResonantSweepWindow;
+                auto wph = ph & phase::phaseMask;
+                float window;
+                if constexpr (R == RW::TRIANGLE)
+                    window = resonant_window::windowTriangle(wph);
+                else if constexpr (R == RW::TRAPEZOID)
+                    window = resonant_window::windowTrapezoid(wph);
+                else if constexpr (R == RW::FULLTRAP)
+                    window = resonant_window::windowFullTrapezoid(wph);
+                else if constexpr (R == RW::HANN || R == RW::BLACKMAN_HARRIS || R == RW::TUKEY)
+                    window = stWindow.at(wph);
+                else // RW::SAW and any unhandled future value — keep `window` defined.
+                    window = resonant_window::windowSaw(wph);
+                // Inner phase runs at k(m)x the fundamental and natural-wraps at the
+                // fundamental boundary via uint32 multiplication (mod phaseMax).
+                // kScale is the patch-selected sweep depth (2 / 4 / 10).
+                auto kFactor = kScale * nextM + 1.0f;
+                uint32_t kmph = static_cast<uint32_t>(static_cast<float>(wph) * kFactor);
+                nextM += dM;
+                out = window * st.at(kmph);
+            }
+            else
+            {
+                out = st.at(ph);
+            }
 
             out = out * rmLevel[i];
             onto[i] = out;
@@ -506,6 +610,9 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
     }
 
     SinTable st;
+    // Used by RESONANT_SWEEP for table-based windows (Hann / Blackman-Harris / Tukey).
+    // Independent of `st` so the operator's main waveform stays selectable freely.
+    SinTable stWindow;
     float fbVal[2]{0.f, 0.f};
 };
 } // namespace baconpaul::six_sines

--- a/src/dsp/resonant_window.h
+++ b/src/dsp/resonant_window.h
@@ -1,0 +1,92 @@
+/*
+ * Six Sines
+ *
+ * A synth with audio rate modulation.
+ *
+ * Copyright 2024-2025, Paul Walker and Various authors, as described in the github
+ * transaction log.
+ *
+ * This source repo is released under the MIT license, but has
+ * GPL3 dependencies, as such the combined work will be
+ * released under GPL3.
+ *
+ * The source code and license are at https://github.com/baconpaul/six-sines
+ */
+
+#ifndef BACONPAUL_SIX_SINES_DSP_RESONANT_WINDOW_H
+#define BACONPAUL_SIX_SINES_DSP_RESONANT_WINDOW_H
+
+#include <cstdint>
+#include <cmath>
+
+#include "dsp/sintable.h" // baconpaul::six_sines::phase constants
+
+/*
+ * Closed-form window functions for the CZ-style resonant sweep mode.
+ *
+ * Each window is multiplied by sin(2*pi * k(m) * inner_phase) where
+ * inner_phase resets to 0 each time the fundamental phase wraps. The
+ * window itself is a function of the fundamental phase and provides
+ * the spectral body of the waveform.
+ *
+ * Float reference forms (phi in [0, 1)):
+ *     windowSaw(phi)            = 1 - phi
+ *     windowTriangle(phi)       = 1 - |2*phi - 1|
+ *     windowTrapezoid(phi)      = phi < 1/2 ? 1 : 2*(1 - phi)
+ *     windowFullTrapezoid(phi)  = phi < 1/4 ? 4*phi
+ *                               : phi < 3/4 ? 1
+ *                               :             4*(1 - phi)
+ *
+ * Integer-phase signature: phase is a uint32_t in [0, phaseMax),
+ * matching the rest of the engine. Output is a float window amplitude
+ * in [0, 1]. The caller multiplies this by the inner-phase sine.
+ *
+ * Hann / Blackman-Harris / Tukey windows are pulled from the SinTable
+ * (`OpSource::stWindow`) rather than implemented here.
+ */
+
+namespace baconpaul::six_sines::resonant_window
+{
+using namespace baconpaul::six_sines::phase;
+
+static constexpr float invPhaseMaxF = 1.0f / phaseMaxF;
+
+// Form 5 -- Resonant Saw window
+// Descending ramp: 1 at phase = 0, 0 at phase = phaseMax.
+// Hard restart at the wrap is the source of the saw-like spectral envelope.
+inline float windowSaw(uint32_t phase) { return 1.0f - static_cast<float>(phase) * invPhaseMaxF; }
+
+// Form 6 -- Resonant Triangle window
+// Triangle: 0 at phase = 0, peaks at 1 at phase = halfPhase, back to 0 at phase = phaseMax.
+// No discontinuity at the wrap; smoother, more vowel-like resonance.
+inline float windowTriangle(uint32_t phase)
+{
+    const float p = static_cast<float>(phase) * invPhaseMaxF;
+    return 1.0f - std::fabs(2.0f * p - 1.0f);
+}
+
+// Form 7 -- Resonant Trapezoid window
+// Flat at 1 for phase in [0, halfPhase), then linear decay to 0 at phase = phaseMax.
+// Pulse-like body with a strong formant from the hard restart at phase = 0.
+inline float windowTrapezoid(uint32_t phase)
+{
+    if (phase < halfPhase)
+        return 1.0f;
+    return 2.0f * (1.0f - static_cast<float>(phase) * invPhaseMaxF);
+}
+
+// Symmetric full trapezoid: 0 -> 1 over [0, 1/4), held at 1 over [1/4, 3/4),
+// 1 -> 0 over [3/4, 1). No discontinuity at the wrap; flat-topped pulse body.
+inline float windowFullTrapezoid(uint32_t phase)
+{
+    constexpr uint32_t quarterPhase = phaseMax >> 2;
+    constexpr uint32_t threeQuarterPhase = quarterPhase * 3;
+    if (phase < quarterPhase)
+        return 4.0f * static_cast<float>(phase) * invPhaseMaxF;
+    if (phase < threeQuarterPhase)
+        return 1.0f;
+    return 4.0f * (1.0f - static_cast<float>(phase) * invPhaseMaxF);
+}
+
+} // namespace baconpaul::six_sines::resonant_window
+#endif

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -87,6 +87,8 @@ struct Patch : pats::PatchBase<Patch, Param>
     static constexpr uint64_t version_120b = 0x010202;
     // third chunk of 1.2.0: super macros
     static constexpr uint64_t version_120c = 0x010203;
+    // Fourth chunk of 1.2.0: resonant sweeps
+    static constexpr uint64_t version_120d = 0x010204;
 
     static md_t baseMd(uint64_t version = version_110) { return md_t().withVersion(version); }
     static md_t floatMd(uint64_t version = version_110)
@@ -531,6 +533,24 @@ struct Patch : pats::PatchBase<Patch, Param>
             DOUBLE_SAW = 5
         };
 
+        enum struct ResonantSweepWindow : uint32_t
+        {
+            SAW = 0,
+            TRIANGLE = 1,
+            TRAPEZOID = 2,
+            FULLTRAP = 3,
+            HANN = 4,
+            BLACKMAN_HARRIS = 5,
+            TUKEY = 6,
+        };
+
+        enum struct ResonantSweepFrequencyDepth : uint32_t
+        {
+            TWO = 0,
+            FOUR = 1,
+            TEN = 2,
+        };
+
         SourceNode(size_t idx)
             : ratio(floatMd()
                         .withRange(-5, 5)
@@ -757,7 +777,34 @@ struct Patch : pats::PatchBase<Patch, Param>
                                         {(int)PhaseMapShape::DOUBLE, "Double (CZ4)"},
                                         {(int)PhaseMapShape::SIN_TO_SQUARE, "Sin to Square"},
                                         {(int)PhaseMapShape::DOUBLE_SAW, "Sin to Saw"},
-                                    }))
+                                    })),
+              resonantSweepWindowShape(
+                  intMd(version_120d)
+                      .withRange(0, 6)
+                      .withDefault(0)
+                      .withID(id(183, idx))
+                      .withName(name(idx) + " Resonant Sweep Window")
+                      .withGroupName(name(idx))
+                      .withUnorderedMapFormatting({
+                          {(int)ResonantSweepWindow::SAW, "Saw"},
+                          {(int)ResonantSweepWindow::TRIANGLE, "Tri"},
+                          {(int)ResonantSweepWindow::TRAPEZOID, "1/2 Trap"},
+                          {(int)ResonantSweepWindow::FULLTRAP, "Full Trap"},
+                          {(int)ResonantSweepWindow::HANN, "Hann"},
+                          {(int)ResonantSweepWindow::BLACKMAN_HARRIS, "Blkmn/Harris"},
+                          {(int)ResonantSweepWindow::TUKEY, "Tukey"},
+                      })),
+              resonantSweepFrequencyDepth(intMd(version_120d)
+                                              .withRange(0, 2)
+                                              .withDefault(1)
+                                              .withID(id(184, idx))
+                                              .withName(name(idx) + " Sweep Depth")
+                                              .withGroupName(name(idx))
+                                              .withUnorderedMapFormatting({
+                                                  {(int)ResonantSweepFrequencyDepth::TWO, "2 oct"},
+                                                  {(int)ResonantSweepFrequencyDepth::FOUR, "4 oct"},
+                                                  {(int)ResonantSweepFrequencyDepth::TEN, "10 oct"},
+                                              }))
 
         {
             index = idx;
@@ -798,6 +845,8 @@ struct Patch : pats::PatchBase<Patch, Param>
         Param lfoToExtendedModeM, lfoToExtendedModeN;
 
         Param phaseMapModeShape;
+        Param resonantSweepWindowShape;
+        Param resonantSweepFrequencyDepth;
 
         std::array<Param, numModsPer> modtarget;
 
@@ -826,7 +875,9 @@ struct Patch : pats::PatchBase<Patch, Param>
                                      &envToExtendedModeN,
                                      &lfoToExtendedModeM,
                                      &lfoToExtendedModeN,
-                                     &phaseMapModeShape};
+                                     &phaseMapModeShape,
+                                     &resonantSweepWindowShape,
+                                     &resonantSweepFrequencyDepth};
             for (int i = 0; i < numModsPer; ++i)
                 res.push_back(&modtarget[i]);
             appendDAHDSRParams(res);

--- a/src/ui/source-sub-panel.cpp
+++ b/src/ui/source-sub-panel.cpp
@@ -243,7 +243,7 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
         auto em = static_cast<EM>(static_cast<int>(
             std::round(w->editor.patchCopy.sourceNodes[w->index].extendedModeMode.value)));
         if (tid == TID::EXTEND_M)
-            return em == EM::PHASE_REMAP;
+            return em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP;
         if (tid == TID::EXTEND_N)
             return false;
         return true;
@@ -436,6 +436,23 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
                                                   sn.phaseMapModeShape, editor);
     addChildComponent(*pdWavPainter);
 
+    createComponent(editor, *this, sn.resonantSweepWindowShape, resonantWindowShape,
+                    resonantWindowShapeD);
+    addChildComponent(*resonantWindowShape);
+    traverse(resonantWindowShape);
+
+    createComponent(editor, *this, sn.resonantSweepFrequencyDepth, resonantSweepDepth,
+                    resonantSweepDepthD);
+    addChildComponent(*resonantSweepDepth);
+    traverse(resonantSweepDepth);
+    resonantSweepDepthL = std::make_unique<jcmp::Label>();
+    resonantSweepDepthL->setText("Depth");
+    addChildComponent(*resonantSweepDepthL);
+
+    resonantSweepPlotPlaceholderL = std::make_unique<jcmp::Label>();
+    resonantSweepPlotPlaceholderL->setText("plot coming soon");
+    addChildComponent(*resonantSweepPlotPlaceholderL);
+
     // Live-repaint the PD painter when any input it draws from changes.
     auto repaintPD = [w = juce::Component::SafePointer(this)]()
     {
@@ -607,7 +624,54 @@ void SourceSubPanel::resized()
         bodyLo.add(rightCol.expandToFill());
         bodyLo.doLayout();
     }
-    else if (em == EM::RESONANT_SWEEP || em == EM::REDACTED_1)
+    else if (em == EM::RESONANT_SWEEP)
+    {
+        // Layout:
+        //   [ window-shape multi (tall) ] [ depth jog ] [ M ] [ Env->M ] [ LFO->M ]
+        //   [               "plot coming soon" placeholder spanning full width                ]
+        // The window multi has 7 entries so it spans two rows of body height; the
+        // right-side cells are vertically centered in that taller block.
+        constexpr int cellW = uicKnobSize;
+        constexpr int rowH = uicLabeledKnobHeight;
+        constexpr int bodyH = 2 * rowH + uicMargin;
+        auto bodyRect = juce::Rectangle<int>(depx, bodyY, p.getWidth(), bodyH);
+
+        auto knobCell = [](auto &k, auto &l)
+        {
+            auto cell = jlo::VList().withWidth(cellW);
+            cell.add(labelKnobLayout(k, l).centerInParent());
+            return cell;
+        };
+
+        auto bodyLo = jlo::HList()
+                          .at(bodyRect.getX(), bodyRect.getY())
+                          .withWidth(bodyRect.getWidth())
+                          .withHeight(bodyRect.getHeight())
+                          .withAutoGap(uicMargin * 2);
+
+        bodyLo.add(jlo::Component(*resonantWindowShape).withWidth(2 * cellW).withHeight(bodyH));
+
+        constexpr int depthColW = (cellW * 3) / 2;
+        auto depthInner = jlo::VList().withAutoGap(uicLabelGap);
+        depthInner.add(jlo::Component(*resonantSweepDepthL).withHeight(uicLabelHeight));
+        depthInner.add(jlo::Component(*resonantSweepDepth).withHeight(uicLabelHeight));
+        auto depthCol = jlo::VList().withWidth(depthColW);
+        depthCol.add(depthInner.centerInParent());
+        bodyLo.add(depthCol);
+
+        bodyLo.add(knobCell(extM, extML));
+        bodyLo.add(knobCell(envToExtM, envToExtML));
+        bodyLo.add(knobCell(lfoToExtM, lfoToExtML));
+        bodyLo.doLayout();
+
+        // "plot coming soon" placeholder — sits just under the body. Use a small
+        // height so the label hugs the knob row above instead of floating low.
+        constexpr int placeholderH = uicLabelHeight * 2;
+        auto placeholderRect = juce::Rectangle<int>(depx, bodyRect.getBottom() - 10 * uicMargin,
+                                                    p.getWidth(), placeholderH);
+        resonantSweepPlotPlaceholderL->setBounds(placeholderRect);
+    }
+    else if (em == EM::REDACTED_1)
     {
         auto bodyRect = juce::Rectangle<int>(depx, bodyY, p.getWidth(), uicLabeledKnobHeight);
         comingSoonLabel->setBounds(bodyRect);
@@ -622,18 +686,24 @@ void SourceSubPanel::setExtendedModeVisibility()
     auto em = static_cast<EM>(static_cast<int>(std::round(extModeButtonD->getValue())));
 
     auto isPhaseRemap = (em == EM::PHASE_REMAP);
-    auto isComing = (em == EM::RESONANT_SWEEP || em == EM::REDACTED_1);
+    auto isResonantSweep = (em == EM::RESONANT_SWEEP);
+    auto isComing = (em == EM::REDACTED_1);
+    auto showsM = isPhaseRemap || isResonantSweep;
 
     comingSoonLabel->setVisible(isComing);
     phaseMapShape->setVisible(isPhaseRemap);
-    extM->setVisible(isPhaseRemap);
-    extML->setVisible(isPhaseRemap);
-    envToExtM->setVisible(isPhaseRemap);
-    envToExtML->setVisible(isPhaseRemap);
-    lfoToExtM->setVisible(isPhaseRemap);
-    lfoToExtML->setVisible(isPhaseRemap);
+    extM->setVisible(showsM);
+    extML->setVisible(showsM);
+    envToExtM->setVisible(showsM);
+    envToExtML->setVisible(showsM);
+    lfoToExtM->setVisible(showsM);
+    lfoToExtML->setVisible(showsM);
     if (pdWavPainter)
         pdWavPainter->setVisible(isPhaseRemap);
+    resonantWindowShape->setVisible(isResonantSweep);
+    resonantSweepDepth->setVisible(isResonantSweep);
+    resonantSweepDepthL->setVisible(isResonantSweep);
+    resonantSweepPlotPlaceholderL->setVisible(isResonantSweep);
 }
 
 void SourceSubPanel::setEnabledState()
@@ -680,6 +750,8 @@ void SourceSubPanel::setEnabledState()
     // Extended-mode controls (disabled wholesale on AUDIO_IN)
     extModeButton->setEnabled(!isAudioIn);
     phaseMapShape->setEnabled(!isAudioIn);
+    resonantWindowShape->setEnabled(!isAudioIn);
+    resonantSweepDepth->setEnabled(!isAudioIn);
     extM->setEnabled(!isAudioIn);
     envToExtM->setEnabled(!isAudioIn);
     lfoToExtM->setEnabled(!isAudioIn);

--- a/src/ui/source-sub-panel.h
+++ b/src/ui/source-sub-panel.h
@@ -92,6 +92,14 @@ struct SourceSubPanel : juce::Component,
     std::unique_ptr<jcmp::Label> extML, envToExtML, lfoToExtML;
     std::unique_ptr<juce::Component> pdWavPainter;
 
+    // Resonant sweep body components
+    std::unique_ptr<jcmp::MultiSwitch> resonantWindowShape;
+    std::unique_ptr<PatchDiscrete> resonantWindowShapeD;
+    std::unique_ptr<jcmp::JogUpDownButton> resonantSweepDepth;
+    std::unique_ptr<PatchDiscrete> resonantSweepDepthD;
+    std::unique_ptr<jcmp::Label> resonantSweepDepthL;
+    std::unique_ptr<jcmp::Label> resonantSweepPlotPlaceholderL;
+
     void setExtendedModeVisibility();
 
     std::unique_ptr<jcmp::HSliderFilled> keyTrackValue;


### PR DESCRIPTION
A new RESONANT_SWEEP option in each operator's extended mode multiplies a sine running at k(m)x the fundamental by a fundamental-phase window, giving CZ-style formant resonance. Closed-form windows (saw, triangle, half-trapezoid, full-trapezoid) live in dsp/resonant_window.h; the table-based windows (Hann, Blackman-Harris, Tukey) reuse the existing SinTable via a second SinTable member on OpSource.

Two new per-op params: a window-shape selector and a "Sweep Depth" selector (2 / 4 / 10) that scales how aggressively k(m) climbs with M. The existing M / Env->M / LFO->M controls are reused for both PHASE_REMAP and RESONANT_SWEEP modes. UI gets a multiswitch + jog button + placeholder for the future spectrum plot.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>