### PR TITLE
Add output stage with saturation, bit-rate / depth crush, cuts, and gain

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,6 @@
 [submodule "libs/sst/sst-cmake"]
 	path = libs/sst/sst-cmake
 	url = https://github.com/surge-synthesizer/sst-cmake
+[submodule "libs/sst/sst-filters"]
+	path = libs/sst/sst-filters
+	url = https://github.com/surge-synthesizer/sst-filters

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ target_link_libraries(${PROJECT_NAME}-impl PUBLIC  # PW change to public since w
         sst-plugininfra::strnatcmp
         sst-plugininfra::patchbase
         sst-plugininfra::version_information
+        sst-filters
         sst::clap_juce_shim sst::clap_juce_shim_headers
         juce::juce_dsp
         ${PROJECT_NAME}-patches

--- a/doc/12_roadmap.md
+++ b/doc/12_roadmap.md
@@ -3,25 +3,13 @@
 I have a lot of ideas for a '1.2' version of six sines. Not 2.0. Still compatible. But expanded. Here's my rough list
 
 
-## Upgrades to the Resampler, Final path, and Reconstruction
+## MPE Pitch Bend
 
-- Make the upsample / downsample path have more control and better viz
-- Specifically have the pipeline be
-  - Run at internal sample rate to make high bit rate clean signal
-  - Soft drive saturator (use the cubic clamp form) with optional small drive
-  - Add a cytomic SVF at 16khz / root 2 resonance
-  - ZOH decimate the signal to 32khz at upper rate
-  - Do a bitheight redicution (round(f * (1<<b)) / (1<<b))
-  - Add an optional highpass at 5-15hz to kill DC
-  - Downsample with strategy
-- Each of those steps except the first and last is optional.
-- basically all options to make it less 'clean' which all toggle at internal block
+- basically in mpe mode interpolate between keys for mts tuning in voice.cpp
+
+## Pink Noise as mode
 
 
-## Granular FM
-
-- that crazy idea kisney and i chatted about
-- more t/k
 
 ## Infrastructure
 
@@ -42,6 +30,20 @@ Want modes - like segmented float,
 ## Visualization **DONE**
 
 - Add a simple built in spectrum and scope
+
+## Upgrades to the Resampler, Final path, and Reconstruction **DONE**
+
+- Make the upsample / downsample path have more control and better viz
+- Specifically have the pipeline be
+  - Run at internal sample rate to make high bit rate clean signal
+  - Soft drive saturator (use the cubic clamp form) with optional small drive
+  - Add a cytomic SVF at 16khz / root 2 resonance
+  - ZOH decimate the signal to 32khz at upper rate
+  - Do a bitheight redicution (round(f * (1<<b)) / (1<<b))
+  - Add an optional highpass at 5-15hz to kill DC
+  - Downsample with strategy
+- Each of those steps except the first and last is optional.
+- basically all options to make it less 'clean' which all toggle at internal block
 
 ## Super-Macros **DONE**
 
@@ -66,6 +68,11 @@ Want modes - like segmented float,
 
 
 # 1.3 Roadmap (pushed from 1.2)
+
+## Granular FM
+
+- that crazy idea kisney and i chatted about
+- more t/k
 
 ## User Wavetables (May not do)
 

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -16,6 +16,7 @@ add_subdirectory(sst/sst-cpputils)
 add_subdirectory(sst/sst-basic-blocks)
 add_subdirectory(sst/sst-jucegui)
 add_subdirectory(sst/sst-voicemanager)
+add_subdirectory(sst/sst-filters)
 
 set(SST_PLUGININFRA_PROVIDE_TINYXML ON CACHE BOOL "yesxml")
 set(SST_PLUGININFRA_PROVIDE_PATCHBASE ON CACHE BOOL "patchbase pls")

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -62,6 +62,49 @@ enum ResamplerEngine
     ZOH
 };
 
+// Output signal-path stage settings (streamed)
+enum SaturationType
+{
+    SAT_NONE = 0,
+    SAT_SOFT = 1,
+    SAT_OJD = 2
+};
+
+enum LowpassMode
+{
+    LP_NONE = 0,
+    LP_7K5 = 1,
+    LP_10K = 2,
+    LP_13K = 3,
+    LP_16K = 4,
+    LP_20K = 5
+};
+
+enum BitRateMode
+{
+    BR_NONE = 0,
+    BR_16K_ZOH = 1,
+    BR_24K_ZOH = 2,
+    BR_32K_ZOH = 3,
+    BR_48K_ZOH = 4
+};
+
+enum BitDepthMode
+{
+    BD_NONE = 0,
+    BD_8 = 1,
+    BD_12 = 2,
+    BD_16 = 3
+};
+
+enum HighpassMode
+{
+    HP_NONE = 0,
+    HP_10HZ = 1,
+    HP_20HZ = 2,
+    HP_50HZ = 3
+};
+
 } // namespace baconpaul::six_sines
 
 inline std::string fileTrunc(const std::string &f)

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -89,6 +89,8 @@ struct Patch : pats::PatchBase<Patch, Param>
     static constexpr uint64_t version_120c = 0x010203;
     // Fourth chunk of 1.2.0: resonant sweeps
     static constexpr uint64_t version_120d = 0x010204;
+    // Fifth chunk of 1.2.0: output signal-path stages
+    static constexpr uint64_t version_120e = 0x010205;
 
     static md_t baseMd(uint64_t version = version_110) { return md_t().withVersion(version); }
     static md_t floatMd(uint64_t version = version_110)
@@ -1662,6 +1664,83 @@ struct Patch : pats::PatchBase<Patch, Param>
                                      {ResamplerEngine::LINTERP, "Linear Interp"},
                                      {ResamplerEngine::ZOH, "ZOH"},
                                  })),
+              saturationType(intMd(version_120e)
+                                 .withName(name() + " Saturation Type")
+                                 .withGroupName(name())
+                                 .withDefault(SaturationType::SAT_NONE)
+                                 .withRange(SaturationType::SAT_NONE, SaturationType::SAT_OJD)
+                                 .withID(id(50))
+                                 .withUnorderedMapFormatting({
+                                     {SaturationType::SAT_NONE, "None"},
+                                     {SaturationType::SAT_SOFT, "Soft"},
+                                     {SaturationType::SAT_OJD, "OJD"},
+                                 })),
+              saturationDrive(floatMd(version_120e)
+                                  .asCubicDecibelUpTo(0.f)
+                                  .withRange(1.f, 3.f)
+                                  .withDefault(1.f)
+                                  .withName(name() + " Saturation Drive")
+                                  .withGroupName(name())
+                                  .withID(id(51))),
+              lowpass(intMd(version_120e)
+                          .withName(name() + " Low Pass")
+                          .withGroupName(name())
+                          .withDefault(LowpassMode::LP_NONE)
+                          .withRange(LowpassMode::LP_NONE, LowpassMode::LP_20K)
+                          .withID(id(52))
+                          .withUnorderedMapFormatting({
+                              {LowpassMode::LP_NONE, "None"},
+                              {LowpassMode::LP_7K5, "7.5 kHz"},
+                              {LowpassMode::LP_10K, "10 kHz"},
+                              {LowpassMode::LP_13K, "13 kHz"},
+                              {LowpassMode::LP_16K, "16 kHz"},
+                              {LowpassMode::LP_20K, "20 kHz"},
+                          })),
+              bitRateAdjust(intMd(version_120e)
+                                .withName(name() + " Bit Rate Adjust")
+                                .withGroupName(name())
+                                .withDefault(BitRateMode::BR_NONE)
+                                .withRange(BitRateMode::BR_NONE, BitRateMode::BR_48K_ZOH)
+                                .withID(id(53))
+                                .withUnorderedMapFormatting({
+                                    {BitRateMode::BR_NONE, "None"},
+                                    {BitRateMode::BR_16K_ZOH, "16 kHz ZOH"},
+                                    {BitRateMode::BR_24K_ZOH, "24 kHz ZOH"},
+                                    {BitRateMode::BR_32K_ZOH, "32 kHz ZOH"},
+                                    {BitRateMode::BR_48K_ZOH, "48 kHz ZOH"},
+                                })),
+              bitDepthAdjust(intMd(version_120e)
+                                 .withName(name() + " Bit Depth Adjust")
+                                 .withGroupName(name())
+                                 .withDefault(BitDepthMode::BD_NONE)
+                                 .withRange(BitDepthMode::BD_NONE, BitDepthMode::BD_16)
+                                 .withID(id(54))
+                                 .withUnorderedMapFormatting({
+                                     {BitDepthMode::BD_NONE, "None"},
+                                     {BitDepthMode::BD_8, "8 bit"},
+                                     {BitDepthMode::BD_12, "12 bit"},
+                                     {BitDepthMode::BD_16, "16 bit"},
+                                 })),
+              highpass(intMd(version_120e)
+                           .withName(name() + " High Pass")
+                           .withGroupName(name())
+                           .withDefault(HighpassMode::HP_NONE)
+                           .withRange(HighpassMode::HP_NONE, HighpassMode::HP_50HZ)
+                           .withID(id(55))
+                           .withUnorderedMapFormatting({
+                               {HighpassMode::HP_NONE, "None"},
+                               {HighpassMode::HP_10HZ, "10 Hz"},
+                               {HighpassMode::HP_20HZ, "20 Hz"},
+                               {HighpassMode::HP_50HZ, "50 Hz"},
+                           })),
+              outputGain(floatMd(version_120e)
+                             .asCubicDecibelUpTo(0.f)
+                             .withRange(0.f, 2.f)
+                             .withDefault(1.f)
+                             .withPolarity(md_t::Polarity::BIPOLAR)
+                             .withName(name() + " Output Gain")
+                             .withGroupName(name())
+                             .withID(id(56))),
               unisonPan(floatMd()
                             .withName(name() + " Unison Stereo Field")
                             .asPercent()
@@ -1702,6 +1781,9 @@ struct Patch : pats::PatchBase<Patch, Param>
         Param octTranspose, fineTune, pan, lfoDepth;
         Param attackFloorOnRetrig, rephaseOnRetrigger;
         Param sampleRateStrategy, resampleEngine;
+        Param saturationType, saturationDrive;
+        Param lowpass, bitRateAdjust, bitDepthAdjust, highpass;
+        Param outputGain;
 
         std::array<Param, numModsPer> modtarget;
 
@@ -1730,7 +1812,14 @@ struct Patch : pats::PatchBase<Patch, Param>
                                      &attackFloorOnRetrig,
                                      &rephaseOnRetrigger,
                                      &sampleRateStrategy,
-                                     &resampleEngine};
+                                     &resampleEngine,
+                                     &saturationType,
+                                     &saturationDrive,
+                                     &lowpass,
+                                     &bitRateAdjust,
+                                     &bitDepthAdjust,
+                                     &highpass,
+                                     &outputGain};
             appendDAHDSRParams(res);
 
             for (int i = 0; i < numModsPer; ++i)

--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -230,6 +230,11 @@ void Synth::setSampleRate(double sampleRate)
 
     audioToUi.push(
         {AudioToUIMsg::SEND_SAMPLE_RATE, 0, (float)hostSampleRate, (float)engineSampleRate});
+
+    // Refresh anything keyed off engineSampleRate (filter coefs, ZOH ratio).
+    // Safe vs. recursion: reapplyControlSettings only re-enters setSampleRate
+    // when sampleRateStrategy diverges from the patch, which it doesn't here.
+    reapplyControlSettings();
 }
 
 template <bool multiOut> void Synth::processInternal(const clap_output_events_t *outq)
@@ -368,6 +373,10 @@ template <bool multiOut> void Synth::processInternal(const clap_output_events_t 
             v->next = nullptr;
             assert(!v->next && !v->prior);
         }
+
+        // End-of-chain stages run on the main engine-rate stereo bus,
+        // before downsampling. Per-op buses in multiOut are not processed yet.
+        processEndOfBlock(lOutput[0], lOutput[1]);
 
         if (usesLanczos())
         {
@@ -693,7 +702,10 @@ void Synth::processUIQueue(const clap_output_events_t *outq)
                 dest->meta.id == patch.output.pianoModeActive.meta.id ||
                 dest->meta.id == patch.output.mpeActive.meta.id ||
                 dest->meta.id == patch.output.sampleRateStrategy.meta.id ||
-                dest->meta.id == patch.output.resampleEngine.meta.id)
+                dest->meta.id == patch.output.resampleEngine.meta.id ||
+                dest->meta.id == patch.output.lowpass.meta.id ||
+                dest->meta.id == patch.output.highpass.meta.id ||
+                dest->meta.id == patch.output.bitRateAdjust.meta.id)
             {
                 reapplyControlSettings();
             }
@@ -883,6 +895,157 @@ void Synth::reapplyControlSettings()
     else
     {
         voiceManager->dialect = voiceManager_t::MIDI1Dialect::MIDI1;
+    }
+
+    // End-of-chain high/low cut. The "active" flags gate per-block work.
+    // Coefficient setup over-applies on every reapply for now.
+    auto sr = (float)engineSampleRate;
+
+    auto lpVal = (int)std::round(patch.output.lowpass.value);
+    lpActive = lpVal != LP_NONE;
+    if (lpActive && sr > 0)
+    {
+        float freq = 0;
+        switch (lpVal)
+        {
+        case LP_7K5:
+            freq = 7500.f;
+            break;
+        case LP_10K:
+            freq = 10000.f;
+            break;
+        case LP_13K:
+            freq = 13000.f;
+            break;
+        case LP_16K:
+            freq = 16000.f;
+            break;
+        case LP_20K:
+            freq = 20000.f;
+            break;
+        }
+        lpFilter.setCutoffAndSampleRate(freq, sr);
+        lpFilter.reset();
+    }
+
+    auto brVal = (int)std::round(patch.output.bitRateAdjust.value);
+    bitRateActive = brVal != BR_NONE;
+    if (bitRateActive && sr > 0)
+    {
+        float target = 0;
+        switch (brVal)
+        {
+        case BR_16K_ZOH:
+            target = 16000.f;
+            break;
+        case BR_24K_ZOH:
+            target = 24000.f;
+            break;
+        case BR_32K_ZOH:
+            target = 32000.f;
+            break;
+        case BR_48K_ZOH:
+            target = 48000.f;
+            break;
+        }
+        bitRateZOH.setRate(target, sr);
+        bitRateZOH.reset();
+    }
+
+    auto hpVal = (int)std::round(patch.output.highpass.value);
+    hpActive = hpVal != HP_NONE;
+    if (hpActive && sr > 0)
+    {
+        float freq = 0;
+        switch (hpVal)
+        {
+        case HP_10HZ:
+            freq = 10.f;
+            break;
+        case HP_20HZ:
+            freq = 20.f;
+            break;
+        case HP_50HZ:
+            freq = 50.f;
+            break;
+        }
+        hpFilter.setCutoffAndSampleRate(freq, sr);
+        hpFilter.reset();
+    }
+}
+
+void Synth::processEndOfBlock(float *L, float *R)
+{
+    auto satType = (int)std::round(patch.output.saturationType.value);
+    if (satType != SAT_NONE)
+    {
+        auto dv = patch.output.saturationDrive.value;
+        auto drive = dv * dv * dv;
+        if (satType == SAT_SOFT)
+        {
+            for (int i = 0; i < blockSize; ++i)
+            {
+                L[i] = softSaturator(L[i] * drive);
+                R[i] = softSaturator(R[i] * drive);
+            }
+        }
+        else if (satType == SAT_OJD)
+        {
+            for (int i = 0; i < blockSize; ++i)
+            {
+                L[i] = ojdSaturator(L[i] * drive);
+                R[i] = ojdSaturator(R[i] * drive);
+            }
+        }
+    }
+
+    if (bitRateActive)
+    {
+        for (int i = 0; i < blockSize; ++i)
+            bitRateZOH.step(L[i], R[i]);
+    }
+
+    auto bdVal = (int)std::round(patch.output.bitDepthAdjust.value);
+    if (bdVal != BD_NONE)
+    {
+        int bits = 0;
+        switch (bdVal)
+        {
+        case BD_8:
+            bits = 8;
+            break;
+        case BD_12:
+            bits = 12;
+            break;
+        case BD_16:
+            bits = 16;
+            break;
+        }
+        // bits levels span -1..1, so scale = 2^(bits-1) (e.g. 8 bit → 128 steps each side).
+        auto scale = (float)(1 << (bits - 1));
+        auto invScale = 1.f / scale;
+        for (int i = 0; i < blockSize; ++i)
+        {
+            L[i] = std::round(L[i] * scale) * invScale;
+            R[i] = std::round(R[i] * scale) * invScale;
+        }
+    }
+
+    if (lpActive)
+        lpFilter.processBlock(L, R, blockSize);
+    if (hpActive)
+        hpFilter.processBlock(L, R, blockSize);
+
+    // Output gain: param value v in [0, 2], applied gain = v^3 (display in dB).
+    auto v = patch.output.outputGain.value;
+    auto g = v * v * v;
+    if (g != 1.f)
+    {
+        for (int i = 0; i < blockSize; ++i)
+        {
+            L[i] *= g;
+            R[i] *= g;
+        }
     }
 }
 

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -18,9 +18,11 @@
 
 #include <memory>
 #include <array>
+#include <cassert>
 #include <string>
 
 #include "sst/basic-blocks/dsp/LanczosResampler.h"
+#include "sst/filters/ButterworthLPHP.h"
 #include "samplerate.h"
 
 class TiXmlElement;
@@ -310,6 +312,87 @@ struct Synth
 
     void process(const clap_output_events_t *);
     void processUIQueue(const clap_output_events_t *);
+
+    // End-of-chain processing on the engine-rate stereo bus, in place.
+    // Runs the saturator / lowpass / decimator / bitcrush / highpass stages.
+    void processEndOfBlock(float *L, float *R);
+
+    // End-of-chain stage state. Coefficients are recomputed in
+    // reapplyControlSettings; the active flags gate the per-block work.
+    sst::filters::ButterworthLP<6> lpFilter;
+    sst::filters::ButterworthHP<6> hpFilter;
+    bool lpActive{false}, hpActive{false};
+
+    // ZOH-style bit-rate decimator. Runs at the engine (oversample) rate
+    // but only samples the input every engine_rate / target_rate ticks,
+    // emitting a stair-step (v1 v1 v1 v1 v5 v5 v5 v5 ...) which the SRC
+    // then resamples back up.
+    struct ZOHRateDownsampler
+    {
+        float phase{1.f};
+        float rate{0.f};
+        float lastL{0.f}, lastR{0.f};
+
+        void setRate(float targetRate, float engineRate)
+        {
+            rate = engineRate > 0 ? targetRate / engineRate : 0.f;
+            // step() consumes one phase>=1 per call; rate>1 would lose updates.
+            assert(rate <= 1.f);
+        }
+        void reset()
+        {
+            phase = 1.f;
+            lastL = 0.f;
+            lastR = 0.f;
+        }
+        inline void step(float &L, float &R)
+        {
+            if (phase >= 1.f)
+            {
+                phase -= 1.f;
+                lastL = L;
+                lastR = R;
+            }
+            else
+            {
+                L = lastL;
+                R = lastR;
+            }
+            phase += rate;
+        }
+    };
+    ZOHRateDownsampler bitRateZOH;
+    bool bitRateActive{false};
+
+    // Saturator scalar shapers. Cheap, stateless, per-session — kept
+    // out of sst-waveshapers since this isn't per-voice.
+    static inline float softSaturator(float x)
+    {
+        x = std::clamp(x, -4.f, 4.f);
+        return x * (27.f + x * x) / (27.f + 9.f * x * x);
+    }
+
+    static inline float ojdSaturator(float x)
+    {
+        constexpr float pm17 = -1.7f, p11 = 1.1f;
+        constexpr float pm03 = -0.3f, p09 = 0.9f;
+        constexpr float denLow = 1.f / (4.f * (1.f - 0.3f));
+        constexpr float denHigh = 1.f / (4.f * (1.f - 0.9f));
+
+        if (x <= pm17)
+            return -1.f;
+        if (x >= p11)
+            return 1.f;
+        if (x >= pm03 && x <= p09)
+            return x;
+        if (x < pm03)
+        {
+            auto xl = x - pm03;
+            return (xl + denLow * xl * xl) + pm03;
+        }
+        auto xh = x - p09;
+        return (xh - denHigh * xh * xh) + p09;
+    }
 
     void handleParamValue(Param *p, uint32_t pid, float value);
 

--- a/src/ui/playmode-sub-panel.cpp
+++ b/src/ui/playmode-sub-panel.cpp
@@ -185,16 +185,46 @@ PlayModeSubPanel::PlayModeSubPanel(SixSinesEditor &e) : HasEditor(e)
     addAndMakeVisible(*panicTitle);
 
     outputControlTitle = std::make_unique<jcmp::RuledLabel>();
-    outputControlTitle->setText("Output Control");
+    outputControlTitle->setText("Output Stage (Main)");
     addAndMakeVisible(*outputControlTitle);
 
-    createComponent(editor, *this, editor.patchCopy.output.sampleRateStrategy, srStrat, srStratD);
+    auto &out = editor.patchCopy.output;
+    createComponent(editor, *this, out.sampleRateStrategy, srStrat, srStratD);
     addAndMakeVisible(*srStrat);
-    createComponent(editor, *this, editor.patchCopy.output.resampleEngine, rsEng, rsEngD);
+    createComponent(editor, *this, out.resampleEngine, rsEng, rsEngD);
     addAndMakeVisible(*rsEng);
-    srStratLab = std::make_unique<jcmp::RuledLabel>();
-    srStratLab->setText("Oversampling");
-    addAndMakeVisible(*srStratLab);
+
+    createComponent(editor, *this, out.saturationType, satType, satTypeD);
+    addAndMakeVisible(*satType);
+    createComponent(editor, *this, out.saturationDrive, satDrive, satDriveD);
+    addAndMakeVisible(*satDrive);
+    createComponent(editor, *this, out.lowpass, lowpass, lowpassD);
+    addAndMakeVisible(*lowpass);
+    createComponent(editor, *this, out.bitRateAdjust, bitRate, bitRateD);
+    addAndMakeVisible(*bitRate);
+    createComponent(editor, *this, out.bitDepthAdjust, bitDepth, bitDepthD);
+    addAndMakeVisible(*bitDepth);
+    createComponent(editor, *this, out.highpass, highpass, highpassD);
+    addAndMakeVisible(*highpass);
+    createComponent(editor, *this, out.outputGain, outGain, outGainD);
+    addAndMakeVisible(*outGain);
+
+    auto mkLabel = [this](auto &slot, const std::string &t,
+                          juce::Justification j = juce::Justification::centredRight)
+    {
+        slot = std::make_unique<jcmp::Label>();
+        slot->setText(t);
+        slot->setJustification(j);
+        addAndMakeVisible(*slot);
+    };
+    mkLabel(sampleRateLabel, "Sample Rate:");
+    mkLabel(saturationLabel, "Saturation:");
+    mkLabel(lowpassLabel, "Low Pass:");
+    mkLabel(bitRateLabel, "Bit Rate:");
+    mkLabel(bitDepthLabel, "Bit Depth:");
+    mkLabel(highpassLabel, "High Pass:");
+    mkLabel(outGainLabel, "Output:");
+    mkLabel(downsamplerLabel, "Downsampler:");
 
     setEnabledState();
 }
@@ -256,14 +286,43 @@ void PlayModeSubPanel::resized()
 
     outer.add(topRow);
 
-    auto bottomWidth = 4 * skinny + 3 * 2 * uicMargin;
-    outer.add(titleLabelGaplessLayout(outputControlTitle).withWidth(bottomWidth));
+    auto fullWidth = getWidth() - 2 * uicMargin;
+    outer.add(titleLabelGaplessLayout(outputControlTitle).withWidth(fullWidth));
 
-    auto rsl = jlo::VList().withWidth(bottomWidth).withAutoGap(uicMargin);
-    rsl.add(titleLabelGaplessLayout(srStratLab));
-    rsl.add(jlo::Component(*srStrat).withHeight(uicLabelHeight));
-    rsl.add(jlo::Component(*rsEng).withHeight(uicLabelHeight));
-    outer.add(rsl);
+    // Output signal path. Each row is "Label : [control(s)]". Saturation row also
+    // gets a drive HSlider following the type jog. Future revision will add
+    // arrow connectors between stages.
+    auto pathCol = jlo::VList().withWidth(fullWidth).withAutoGap(uicMargin);
+
+    int labelW = fullWidth / 3;
+
+    auto stageRow = [&](auto &lbl, auto &c1, juce::Component *c2 = nullptr)
+    {
+        auto row = jlo::HList().withHeight(uicLabelHeight).withAutoGap(uicMargin);
+        row.add(jlo::Component(*lbl).withWidth(labelW));
+        if (c2)
+        {
+            // Split the right side: jog on the left (skinny), slider fills the rest
+            row.add(jlo::Component(*c1).withWidth(uicSubPanelColumnWidth * 1.5));
+            row.add(jlo::Component(*c2).expandToFill());
+        }
+        else
+        {
+            row.add(jlo::Component(*c1).expandToFill());
+        }
+        return row;
+    };
+
+    pathCol.add(stageRow(sampleRateLabel, srStrat));
+    pathCol.add(stageRow(saturationLabel, satType, satDrive.get()));
+    pathCol.add(stageRow(bitRateLabel, bitRate));
+    pathCol.add(stageRow(bitDepthLabel, bitDepth));
+    pathCol.add(stageRow(lowpassLabel, lowpass));
+    pathCol.add(stageRow(highpassLabel, highpass));
+    pathCol.add(stageRow(outGainLabel, outGain));
+    pathCol.add(stageRow(downsamplerLabel, rsEng));
+
+    outer.add(pathCol);
 
     outer.doLayout();
 }

--- a/src/ui/playmode-sub-panel.h
+++ b/src/ui/playmode-sub-panel.h
@@ -87,11 +87,24 @@ struct PlayModeSubPanel : juce::Component, HasEditor
 
     std::unique_ptr<jcmp::RuledLabel> outputControlTitle;
 
-    std::unique_ptr<jcmp::RuledLabel> srStratLab;
     std::unique_ptr<jcmp::JogUpDownButton> srStrat;
     std::unique_ptr<PatchDiscrete> srStratD;
     std::unique_ptr<jcmp::JogUpDownButton> rsEng;
     std::unique_ptr<PatchDiscrete> rsEngD;
+
+    std::unique_ptr<jcmp::JogUpDownButton> satType, lowpass, bitRate, bitDepth, highpass;
+    std::unique_ptr<PatchDiscrete> satTypeD, lowpassD, bitRateD, bitDepthD, highpassD;
+
+    std::unique_ptr<jcmp::HSliderFilled> satDrive;
+    std::unique_ptr<PatchContinuous> satDriveD;
+
+    std::unique_ptr<jcmp::HSliderFilled> outGain;
+    std::unique_ptr<PatchContinuous> outGainD;
+    std::unique_ptr<jcmp::Label> outGainLabel;
+
+    std::unique_ptr<jcmp::Label> sampleRateLabel, downsamplerLabel;
+    std::unique_ptr<jcmp::Label> saturationLabel, lowpassLabel, bitRateLabel, bitDepthLabel,
+        highpassLabel;
 
     void showPolyLimitMenu();
     int getPolyLimit();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(six-sines-test
 
 		structure.cpp
 		factory_patches.cpp
+		output_stage_dsp.cpp
 )
 
 target_link_libraries(six-sines-test

--- a/tests/output_stage_dsp.cpp
+++ b/tests/output_stage_dsp.cpp
@@ -1,0 +1,134 @@
+/*
+ * Output-stage DSP regression tests. Pin numeric output of the saturator
+ * shapers and the ZOH bit-rate decimator so they don't drift.
+ */
+
+#include "catch2/catch2.hpp"
+#include "synth/synth.h"
+
+#include <array>
+#include <cmath>
+
+using baconpaul::six_sines::Synth;
+
+TEST_CASE("softSaturator golden", "[output_stage]")
+{
+    // Padé-style x*(27+x²)/(27+9x²) clamped to [-4, 4].
+    // Smooth, monotonic, with y(0)=0 and asymptotic ~1 inside the clamp.
+    SECTION("zero in, zero out") { REQUIRE(Synth::softSaturator(0.f) == 0.f); }
+
+    SECTION("odd symmetry")
+    {
+        for (float x : {0.1f, 0.5f, 1.f, 2.f, 3.5f})
+            REQUIRE(Synth::softSaturator(-x) == Approx(-Synth::softSaturator(x)));
+    }
+
+    SECTION("clamp at +/- 4")
+    {
+        // Beyond +-4 the input is clamped, so output equals the boundary value.
+        auto top = Synth::softSaturator(4.f);
+        REQUIRE(Synth::softSaturator(10.f) == top);
+        REQUIRE(Synth::softSaturator(-10.f) == -top);
+    }
+
+    SECTION("known anchors")
+    {
+        // 0.5 * (27 + 0.25) / (27 + 2.25) = 13.625 / 29.25
+        REQUIRE(Synth::softSaturator(0.5f) == Approx(13.625f / 29.25f).margin(1e-6));
+        // 1 * 28 / 36 = 7/9
+        REQUIRE(Synth::softSaturator(1.f) == Approx(7.f / 9.f).margin(1e-6));
+        // 2 * 31 / 63 = 62/63
+        REQUIRE(Synth::softSaturator(2.f) == Approx(62.f / 63.f).margin(1e-6));
+        // At |x|=4 the rational = 4*43/171 = 172/171
+        REQUIRE(Synth::softSaturator(4.f) == Approx(172.f / 171.f).margin(1e-6));
+    }
+}
+
+TEST_CASE("ojdSaturator golden", "[output_stage]")
+{
+    // Multi-region polynomial. Verify the region boundaries are continuous
+    // and the rails saturate correctly.
+    SECTION("hard rails") { REQUIRE(Synth::ojdSaturator(-2.f) == -1.f); }
+    SECTION("hard rail high") { REQUIRE(Synth::ojdSaturator(2.f) == 1.f); }
+
+    SECTION("identity in the middle region")
+    {
+        for (float x : {-0.3f, -0.2f, 0.f, 0.4f, 0.9f})
+            REQUIRE(Synth::ojdSaturator(x) == Approx(x));
+    }
+
+    SECTION("low-region boundary continuity")
+    {
+        // At x=-1.7 the low region equals the negative rail.
+        REQUIRE(Synth::ojdSaturator(-1.7f) == Approx(-1.f).margin(1e-6));
+    }
+
+    SECTION("high-region boundary continuity")
+    {
+        // At x=1.1 the high region reaches +1.
+        REQUIRE(Synth::ojdSaturator(1.1f) == Approx(1.f).margin(1e-6));
+    }
+
+    SECTION("known anchors")
+    {
+        // Low region: x=-1.0 → xl=-0.7, denLow=1/(4*0.7), v = (-0.7 + denLow*0.49) - 0.3
+        REQUIRE(Synth::ojdSaturator(-1.0f) == Approx(-0.825f).margin(1e-6));
+        // High region: x=1.0 → xh=0.1, denHigh=1/(4*0.1), v = (0.1 - denHigh*0.01) + 0.9
+        REQUIRE(Synth::ojdSaturator(1.0f) == Approx(0.975f).margin(1e-6));
+    }
+}
+
+TEST_CASE("ZOHRateDownsampler golden", "[output_stage]")
+{
+    Synth::ZOHRateDownsampler z;
+
+    SECTION("4x downsample produces v1 v1 v1 v1 v5 v5 v5 v5 ...")
+    {
+        z.setRate(32000.f, 128000.f);
+        z.reset();
+
+        std::array<float, 8> in{1, 2, 3, 4, 5, 6, 7, 8};
+        std::array<float, 8> rIn = in;
+        std::array<float, 8> expected{1, 1, 1, 1, 5, 5, 5, 5};
+
+        for (int i = 0; i < 8; ++i)
+            z.step(in[i], rIn[i]);
+
+        for (int i = 0; i < 8; ++i)
+        {
+            REQUIRE(in[i] == Approx(expected[i]));
+            REQUIRE(rIn[i] == Approx(expected[i]));
+        }
+    }
+
+    SECTION("rate=1 passes through")
+    {
+        z.setRate(48000.f, 48000.f);
+        z.reset();
+        std::array<float, 4> in{0.1f, 0.2f, 0.3f, 0.4f};
+        std::array<float, 4> rIn = in;
+        for (int i = 0; i < 4; ++i)
+            z.step(in[i], rIn[i]);
+        for (int i = 0; i < 4; ++i)
+        {
+            REQUIRE(in[i] == Approx(0.1f * (i + 1)));
+        }
+    }
+
+    SECTION("non-integer ratio sample pattern")
+    {
+        // 3:5 ratio: rate = 0.6, ticks where phase>=1 are samples 0, 2, 4, ...
+        // phase init 1.0: sample0=in0 (phase->0+0.6=0.6), sample1=last (0.6+0.6=1.2),
+        // sample2=in2 (phase->0.2+0.6=0.8), sample3=last (0.8+0.6=1.4),
+        // sample4=in4 (phase->0.4+0.6=1.0), sample5=in5 (1.0->0+0.6=0.6).
+        z.setRate(3.f, 5.f);
+        z.reset();
+        std::array<float, 6> in{10, 20, 30, 40, 50, 60};
+        std::array<float, 6> rIn = in;
+        std::array<float, 6> expected{10, 10, 30, 30, 50, 60};
+        for (int i = 0; i < 6; ++i)
+            z.step(in[i], rIn[i]);
+        for (int i = 0; i < 6; ++i)
+            REQUIRE(in[i] == Approx(expected[i]));
+    }
+}


### PR DESCRIPTION
The Output Stage (Main) on the engine-rate stereo bus now offers a selectable soft or OJD saturator with cubic-decibel drive, a ZOH bit-rate decimator (16/24/32/48 kHz), a -1..1 bit-depth quantizer (8/12/16 bit), 4-pole Butterworth low- and high-pass cuts (7.5/10/13/16/20 kHz; 10/20/50 Hz), and a bipolar cubic-decibel output gain. The settings panel exposes the chain as a labelled signal-path stack.

Pulls in sst-filters as a submodule for the Butterworth cascade and adds golden tests for the saturator shapers and ZOH decimator.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>