### PR TITLE
Add pink-noise extended mode for source operators

### DIFF
--- a/doc/12_roadmap.md
+++ b/doc/12_roadmap.md
@@ -2,14 +2,11 @@
 
 I have a lot of ideas for a '1.2' version of six sines. Not 2.0. Still compatible. But expanded. Here's my rough list
 
+## Reset when automated memory for clap edge with output stage
 
 ## MPE Pitch Bend
 
 - basically in mpe mode interpolate between keys for mts tuning in voice.cpp
-
-## Pink Noise as mode
-
-
 
 ## Infrastructure
 
@@ -21,7 +18,9 @@ I have a lot of ideas for a '1.2' version of six sines. Not 2.0. Still compatibl
 
 - Implement phase remap **done**
 - Implement phase formant sweep + window style **done**
-- 
+
+## Pink Noise as mode **DONE**
+
 ## UI Ratio editor Upgrade **DONE**
 
 The ratio editor is a knob. That's clumsy. segmented control will be better.

--- a/src/dsp/op_source.h
+++ b/src/dsp/op_source.h
@@ -21,6 +21,8 @@
 
 #include "configuration.h"
 
+#include "sst/basic-blocks/dsp/PinkNoise.h"
+
 #include "dsp/sintable.h"
 #include "dsp/node_support.h"
 #include "synth/patch.h"
@@ -70,7 +72,8 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
           waveForm(sn.waveForm), kt(sn.keyTrack), ktv(sn.keyTrackValue),
           ktlo(sn.keyTrackValueIsLow), ktlov(sn.keyTrackLowFrequencyValue),
           startPhase(sn.startingPhase), octTranspose(sn.octTranspose),
-          lfoToRatioFine(sn.lfoToRatioFine), envToRatioFine(sn.envToRatioFine)
+          lfoToRatioFine(sn.lfoToRatioFine), envToRatioFine(sn.envToRatioFine),
+          pinkNoise(mv.rng.unifU32())
     {
         reset();
     }
@@ -115,11 +118,11 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
             using EM = Patch::SourceNode::ExtendedMode;
             auto em = static_cast<EM>(
                 static_cast<uint32_t>(std::round(sourceNode.extendedModeMode.value)));
-            if (em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP)
+            if (em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP || em == EM::PINK_NOISE)
             {
                 extendedLagM.setRateInMilliseconds(10, monoValues.sr.samplerate, blockSizeInv);
                 extendedLagM.snapTo(sourceNode.extendedModeM.value);
-                // N is unused in PHASE_REMAP / RESONANT_SWEEP — leave its lag uninitialized
+                // N is unused in all current extended modes — leave its lag uninitialized
                 // until a future mode that consumes N is added.
             }
         }
@@ -191,7 +194,7 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
         using EM = Patch::SourceNode::ExtendedMode;
         auto em =
             static_cast<EM>(static_cast<uint32_t>(std::round(sourceNode.extendedModeMode.value)));
-        if (em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP)
+        if (em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP || em == EM::PINK_NOISE)
             used = used || (sourceNode.lfoToExtendedModeM.value != 0);
 
         return used;
@@ -440,23 +443,49 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
             }
             break;
         }
-        case EM::REDACTED_1:
-            // coming soon — falls through to the no-extension path for now
-            innerLoopImpl<EM::NONE>(onto, fbv, rf, dRF, phs);
+        case EM::PINK_NOISE:
+        {
+            using NM = Patch::SourceNode::NoiseMode;
+            auto nm =
+                static_cast<NM>(static_cast<uint32_t>(std::round(sourceNode.pinkNoiseMode.value)));
+            constexpr auto PMSAW = Patch::SourceNode::PhaseMapShape::SAW;
+            constexpr auto RWSAW = Patch::SourceNode::ResonantSweepWindow::SAW;
+            switch (nm)
+            {
+            case NM::ADD_TO_PHASE:
+                innerLoopImpl<EM::PINK_NOISE, PMSAW, RWSAW, NM::ADD_TO_PHASE>(onto, fbv, rf, dRF,
+                                                                              phs);
+                break;
+            case NM::ADD_TO_SIGNAL:
+                innerLoopImpl<EM::PINK_NOISE, PMSAW, RWSAW, NM::ADD_TO_SIGNAL>(onto, fbv, rf, dRF,
+                                                                               phs);
+                break;
+            case NM::MIX_WITH_SIGNAL:
+                innerLoopImpl<EM::PINK_NOISE, PMSAW, RWSAW, NM::MIX_WITH_SIGNAL>(onto, fbv, rf, dRF,
+                                                                                 phs);
+                break;
+            case NM::MUL_BY_SIGNAL:
+                innerLoopImpl<EM::PINK_NOISE, PMSAW, RWSAW, NM::MUL_BY_SIGNAL>(onto, fbv, rf, dRF,
+                                                                               phs);
+                break;
+            }
             break;
+        }
         }
     }
 
     template <
         Patch::SourceNode::ExtendedMode ET,
         Patch::SourceNode::PhaseMapShape S = Patch::SourceNode::PhaseMapShape::SAW,
-        Patch::SourceNode::ResonantSweepWindow R = Patch::SourceNode::ResonantSweepWindow::SAW>
+        Patch::SourceNode::ResonantSweepWindow R = Patch::SourceNode::ResonantSweepWindow::SAW,
+        Patch::SourceNode::NoiseMode NM = Patch::SourceNode::NoiseMode::ADD_TO_PHASE>
     void innerLoopImpl(float *onto, float *fbv, float rf, const float dRF, uint32_t &phs,
                        float kScale = 1.0f)
     {
         using EM = Patch::SourceNode::ExtendedMode;
+        using NMode = Patch::SourceNode::NoiseMode;
         float nextM{0.f}, dM{0.f};
-        if constexpr (ET == EM::PHASE_REMAP || ET == EM::RESONANT_SWEEP)
+        if constexpr (ET == EM::PHASE_REMAP || ET == EM::RESONANT_SWEEP || ET == EM::PINK_NOISE)
         {
             // Raw target m for this block: patch value + external mod + env / lfo contributions.
             auto lfoFac = *lfoFacP;
@@ -530,6 +559,36 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
                 uint32_t kmph = static_cast<uint32_t>(static_cast<float>(wph) * kFactor);
                 nextM += dM;
                 out = window * st.at(kmph);
+            }
+            else if constexpr (ET == EM::PINK_NOISE)
+            {
+                if (noisePos >= 16)
+                {
+                    pinkNoise.generate16(noiseBuf);
+                    noisePos = 0;
+                }
+                float noise = noiseBuf[noisePos++] * Patch::SourceNode::pinkNoiseScale;
+                float m = nextM;
+                nextM += dM;
+                if constexpr (NM == NMode::ADD_TO_PHASE)
+                {
+                    ph += static_cast<int32_t>(m * noise * phase::phaseMaxF *
+                                               Patch::SourceNode::pinkNoisePhaseScale);
+                    out = st.at(ph);
+                }
+                else if constexpr (NM == NMode::ADD_TO_SIGNAL)
+                {
+                    out = st.at(ph) + m * noise;
+                }
+                else if constexpr (NM == NMode::MUL_BY_SIGNAL)
+                {
+                    out = st.at(ph) * (1.f + m * noise);
+                }
+                else // MIX_WITH_SIGNAL
+                {
+                    auto base = st.at(ph);
+                    out = (1.f - m) * base + m * noise;
+                }
             }
             else
             {
@@ -614,6 +673,12 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
     // Independent of `st` so the operator's main waveform stays selectable freely.
     SinTable stWindow;
     float fbVal[2]{0.f, 0.f};
+
+    // PinkNoise generates 16 samples at a time; blockSize is 8 so we drain the buffer
+    // across two blocks. Seeded once at construction; not re-seeded on note retrigger.
+    sst::basic_blocks::dsp::PinkNoise pinkNoise;
+    float noiseBuf alignas(16)[16]{};
+    int noisePos{16};
 };
 } // namespace baconpaul::six_sines
 

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -91,6 +91,8 @@ struct Patch : pats::PatchBase<Patch, Param>
     static constexpr uint64_t version_120d = 0x010204;
     // Fifth chunk of 1.2.0: output signal-path stages
     static constexpr uint64_t version_120e = 0x010205;
+    // Sixth chunk of 1.2.0: pink-noise extended mode
+    static constexpr uint64_t version_120f = 0x010206;
 
     static md_t baseMd(uint64_t version = version_110) { return md_t().withVersion(version); }
     static md_t floatMd(uint64_t version = version_110)
@@ -522,8 +524,22 @@ struct Patch : pats::PatchBase<Patch, Param>
             NONE = 0,           // these value stream
             PHASE_REMAP = 1,    // CZ-style wave 1-4 wav(phase) -> wav(map(phase))
             RESONANT_SWEEP = 2, // CZ-style resonant sweep (5-9)
-            REDACTED_1 = 3      // t-k
+            PINK_NOISE = 3      // pink noise injection
         };
+
+        enum struct NoiseMode : uint32_t
+        {
+            ADD_TO_PHASE = 0,
+            ADD_TO_SIGNAL = 1,
+            MIX_WITH_SIGNAL = 2,
+            MUL_BY_SIGNAL = 3,
+        };
+
+        // Pink noise from PinkNoise.generate16 has roughly ±0.25 typical amplitude;
+        // scale up so M=1 reaches a useful range. ADD_TO_PHASE additionally needs
+        // attenuation since one full cycle of phase jitter is too much.
+        static constexpr float pinkNoiseScale = 4.0f;
+        static constexpr float pinkNoisePhaseScale = 0.1f;
 
         enum struct PhaseMapShape : uint32_t
         {
@@ -728,7 +744,7 @@ struct Patch : pats::PatchBase<Patch, Param>
                                        {(int)ExtendedMode::NONE, "None"},
                                        {(int)ExtendedMode::PHASE_REMAP, "Phase Map"},
                                        {(int)ExtendedMode::RESONANT_SWEEP, "Resonant Sweep"},
-                                       {(int)ExtendedMode::REDACTED_1, "Redacted-1"},
+                                       {(int)ExtendedMode::PINK_NOISE, "Pink Noise"},
                                    })),
               extendedModeM(floatMd(version_120b)
                                 .asPercent()
@@ -806,7 +822,19 @@ struct Patch : pats::PatchBase<Patch, Param>
                                                   {(int)ResonantSweepFrequencyDepth::TWO, "2 oct"},
                                                   {(int)ResonantSweepFrequencyDepth::FOUR, "4 oct"},
                                                   {(int)ResonantSweepFrequencyDepth::TEN, "10 oct"},
-                                              }))
+                                              })),
+              pinkNoiseMode(intMd(version_120f)
+                                .withRange(0, 3)
+                                .withDefault(0)
+                                .withID(id(185, idx))
+                                .withName(name(idx) + " Pink Noise Mode")
+                                .withGroupName(name(idx))
+                                .withUnorderedMapFormatting({
+                                    {(int)NoiseMode::ADD_TO_PHASE, "Add to Phase"},
+                                    {(int)NoiseMode::ADD_TO_SIGNAL, "Add to Signal"},
+                                    {(int)NoiseMode::MIX_WITH_SIGNAL, "Mix"},
+                                    {(int)NoiseMode::MUL_BY_SIGNAL, "Mul by Signal"},
+                                }))
 
         {
             index = idx;
@@ -849,6 +877,7 @@ struct Patch : pats::PatchBase<Patch, Param>
         Param phaseMapModeShape;
         Param resonantSweepWindowShape;
         Param resonantSweepFrequencyDepth;
+        Param pinkNoiseMode;
 
         std::array<Param, numModsPer> modtarget;
 
@@ -879,7 +908,8 @@ struct Patch : pats::PatchBase<Patch, Param>
                                      &lfoToExtendedModeN,
                                      &phaseMapModeShape,
                                      &resonantSweepWindowShape,
-                                     &resonantSweepFrequencyDepth};
+                                     &resonantSweepFrequencyDepth,
+                                     &pinkNoiseMode};
             for (int i = 0; i < numModsPer; ++i)
                 res.push_back(&modtarget[i]);
             appendDAHDSRParams(res);

--- a/src/ui/source-sub-panel.cpp
+++ b/src/ui/source-sub-panel.cpp
@@ -23,6 +23,7 @@
 #include "dsp/sintable.h" // for drawing
 #include "dsp/remap_functions.h"
 #include "dsp/resonant_window.h"
+#include "sst/basic-blocks/dsp/PinkNoise.h"
 
 namespace baconpaul::six_sines::ui
 {
@@ -401,6 +402,129 @@ struct ResSweepPlotter : juce::Component
     }
 };
 
+/*
+ * PinkNoisePainter shows the result of applying the active NoiseMode to the current
+ * waveform with a fixed-seed pink noise source so the picture is reproducible. We
+ * draw the underlying waveform faintly behind, the noise sequence dotted, and the
+ * combined result on top.
+ */
+struct PinkNoisePainter : juce::Component
+{
+    const Param &wf, &ph, &mp, &noiseMode;
+    SixSinesEditor &editor;
+    SinTable st;
+
+    static constexpr int numCycles{2};
+    static constexpr uint32_t fixedSeed{0xDEC0DE42u};
+
+    PinkNoisePainter(const Param &w, const Param &p, const Param &mParam, const Param &nMode,
+                     SixSinesEditor &e)
+        : wf(w), ph(p), mp(mParam), noiseMode(nMode), editor(e)
+    {
+    }
+
+    void paint(juce::Graphics &g) override
+    {
+        auto labelCol = editor.style()->getColour(jcmp::base_styles::BaseLabel::styleClass,
+                                                  jcmp::base_styles::BaseLabel::labelcolor);
+        auto gridCol = labelCol.withAlpha(0.3f);
+        auto wavCol = editor.style()->getColour(jcmp::base_styles::ValueBearing::styleClass,
+                                                jcmp::base_styles::ValueBearing::value);
+        auto bg = editor.style()->getColour(jcmp::base_styles::PushButton::styleClass,
+                                            jcmp::base_styles::PushButton::fill);
+        g.fillAll(bg);
+        g.setColour(gridCol);
+        g.drawRect(getLocalBounds(), 1.f);
+
+        auto wfVal = (SinTable::WaveForm)std::round(wf.value);
+        if (wfVal == SinTable::AUDIO_IN)
+        {
+            g.setColour(labelCol);
+            g.setFont(juce::Font(juce::FontOptions{}.withHeight(20.f)));
+            g.drawFittedText("Audio In", getLocalBounds(), juce::Justification::centred, 1);
+            return;
+        }
+
+        const int midY = getHeight() / 2;
+        g.setColour(gridCol);
+        g.drawHorizontalLine(midY, 0, getWidth());
+        const int totalQuarters = numCycles * 4;
+        for (int q = 1; q < totalQuarters; ++q)
+        {
+            int x = static_cast<int>(static_cast<float>(q) / totalQuarters * getWidth());
+            int halfTick = (q % 4 == 0) ? 10 : 5;
+            g.drawVerticalLine(x, midY - halfTick, midY + halfTick);
+        }
+
+        st.setWaveForm(wfVal);
+
+        using NM = Patch::SourceNode::NoiseMode;
+        const auto nm = static_cast<NM>(static_cast<uint32_t>(std::round(noiseMode.value)));
+        const float m = mp.value;
+
+        const uint32_t phStart = static_cast<uint32_t>((1u << 26) * ph.value) & phase::phaseMask;
+        const int nPixels = getWidth();
+        const float h = static_cast<float>(getHeight() - 2);
+        const float ho = 1.f;
+        auto toY = [h, ho](float v) { return (1.f - (v + 1.f) * 0.5f) * h + ho; };
+
+        // Fixed-seed pink noise, refilled into a 16-sample stack buffer as we walk.
+        sst::basic_blocks::dsp::PinkNoise rng(fixedSeed);
+        float noiseBuf alignas(16)[16]{};
+        int noisePos{16};
+
+        juce::Path pOut;
+        for (int i = 0; i < nPixels; ++i)
+        {
+            float t =
+                static_cast<float>(i) / std::max(1, nPixels - 1) * static_cast<float>(numCycles);
+            float wphNorm = t - std::floor(t);
+            uint32_t wph =
+                (static_cast<uint32_t>(wphNorm * phase::phaseMaxF) + phStart) & phase::phaseMask;
+
+            if (noisePos >= 16)
+            {
+                rng.generate16(noiseBuf);
+                noisePos = 0;
+            }
+            float n = noiseBuf[noisePos++] * Patch::SourceNode::pinkNoiseScale;
+            float base = st.at(wph);
+            float out;
+            uint32_t modPh = wph;
+
+            switch (nm)
+            {
+            case NM::ADD_TO_PHASE:
+                modPh = (wph + static_cast<int32_t>(m * n * phase::phaseMaxF *
+                                                    Patch::SourceNode::pinkNoisePhaseScale)) &
+                        phase::phaseMask;
+                out = st.at(modPh);
+                break;
+            case NM::ADD_TO_SIGNAL:
+                out = base + m * n;
+                break;
+            case NM::MUL_BY_SIGNAL:
+                out = base * (1.f + m * n);
+                break;
+            case NM::MIX_WITH_SIGNAL:
+                out = (1.f - m) * base + m * n;
+                break;
+            }
+
+            float x = static_cast<float>(i);
+            float yOut = toY(out * 0.98f);
+
+            if (i == 0)
+                pOut.startNewSubPath(x, yOut);
+            else
+                pOut.lineTo(x, yOut);
+        }
+
+        g.setColour(wavCol);
+        g.strokePath(pOut, juce::PathStrokeType(1.5f));
+    }
+};
+
 void SourceSubPanel::setSelectedIndex(size_t idx)
 {
     index = idx;
@@ -422,7 +546,7 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
         auto em = static_cast<EM>(static_cast<int>(
             std::round(w->editor.patchCopy.sourceNodes[w->index].extendedModeMode.value)));
         if (tid == TID::EXTEND_M)
-            return em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP;
+            return em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP || em == EM::PINK_NOISE;
         if (tid == TID::EXTEND_N)
             return false;
         return true;
@@ -483,6 +607,8 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
             pdWavPainter->repaint();
         if (resSweepPainter)
             resSweepPainter->repaint();
+        if (pinkNoisePainter)
+            pinkNoisePainter->repaint();
         wavButton->repaint();
         setEnabledState();
     };
@@ -505,6 +631,8 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
             w->pdWavPainter->repaint();
         if (w->resSweepPainter)
             w->resSweepPainter->repaint();
+        if (w->pinkNoisePainter)
+            w->pinkNoisePainter->repaint();
     };
 
     startingPhaseL = std::make_unique<jcmp::Label>();
@@ -637,7 +765,15 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
         sn.resonantSweepFrequencyDepth, editor);
     addChildComponent(*resSweepPainter);
 
-    // Live-repaint both extended-mode painters when any input either reads from changes.
+    createComponent(editor, *this, sn.pinkNoiseMode, pinkNoiseMode, pinkNoiseModeD);
+    addChildComponent(*pinkNoiseMode);
+    traverse(pinkNoiseMode);
+
+    pinkNoisePainter = std::make_unique<PinkNoisePainter>(
+        sn.waveForm, sn.startingPhase, sn.extendedModeM, sn.pinkNoiseMode, editor);
+    addChildComponent(*pinkNoisePainter);
+
+    // Live-repaint extended-mode painters when any of their inputs change.
     auto repaintExt = [w = juce::Component::SafePointer(this)]()
     {
         if (!w)
@@ -646,15 +782,19 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
             w->pdWavPainter->repaint();
         if (w->resSweepPainter)
             w->resSweepPainter->repaint();
+        if (w->pinkNoisePainter)
+            w->pinkNoisePainter->repaint();
     };
     extMD->onGuiSetValue = repaintExt;
     phaseMapShapeD->onGuiSetValue = repaintExt;
     resonantWindowShapeD->onGuiSetValue = repaintExt;
     resonantSweepDepthD->onGuiSetValue = repaintExt;
+    pinkNoiseModeD->onGuiSetValue = repaintExt;
     editor.componentRefreshByID[sn.extendedModeM.meta.id] = repaintExt;
     editor.componentRefreshByID[sn.phaseMapModeShape.meta.id] = repaintExt;
     editor.componentRefreshByID[sn.resonantSweepWindowShape.meta.id] = repaintExt;
     editor.componentRefreshByID[sn.resonantSweepFrequencyDepth.meta.id] = repaintExt;
+    editor.componentRefreshByID[sn.pinkNoiseMode.meta.id] = repaintExt;
 
     setExtendedModeVisibility();
 
@@ -867,10 +1007,48 @@ void SourceSubPanel::resized()
         bodyLo.add(rightCol.expandToFill());
         bodyLo.doLayout();
     }
-    else if (em == EM::REDACTED_1)
+    else if (em == EM::PINK_NOISE)
     {
-        auto bodyRect = juce::Rectangle<int>(depx, bodyY, p.getWidth(), uicLabeledKnobHeight);
-        comingSoonLabel->setBounds(bodyRect);
+        // Layout mirrors RESONANT_SWEEP:
+        //   [ noise-mode multi ] [ pink-noise painter spans                ]
+        //   [ noise-mode multi ] [ M ] [ Env->M ] [ LFO->M ]
+        constexpr int plotHeight = painterH - 15;
+        constexpr int cellW = uicKnobSize;
+        constexpr int row2H = uicLabeledKnobHeight;
+        constexpr int bodyH = plotHeight + uicMargin + row2H;
+        auto bodyRect = juce::Rectangle<int>(depx, bodyY, p.getWidth(), bodyH);
+
+        auto knobCell = [](auto &k, auto &l)
+        {
+            auto cell = jlo::VList().withWidth(cellW);
+            cell.add(labelKnobLayout(k, l).centerInParent());
+            return cell;
+        };
+
+        auto bodyLo = jlo::HList()
+                          .at(bodyRect.getX(), bodyRect.getY())
+                          .withWidth(bodyRect.getWidth())
+                          .withHeight(bodyRect.getHeight())
+                          .withAutoGap(uicMargin * 2);
+
+        // Left: multiswitch spans full body height
+        auto leftCol = jlo::VList().withWidth(2 * cellW);
+        leftCol.add(jlo::Component(*pinkNoiseMode).withHeight(bodyH));
+        bodyLo.add(leftCol);
+
+        // Right: painter on top, then M / Env->M / LFO->M
+        auto rightCol = jlo::VList().withAutoGap(uicMargin);
+        rightCol.add(jlo::Component(*pinkNoisePainter).withHeight(plotHeight));
+
+        auto knobRow = jlo::HList().withHeight(row2H).withAutoGap(uicMargin);
+        knobRow.add(knobCell(extM, extML));
+        knobRow.add(knobCell(envToExtM, envToExtML));
+        knobRow.add(knobCell(lfoToExtM, lfoToExtML));
+        rightCol.addGap(uicMargin);
+        rightCol.add(knobRow);
+
+        bodyLo.add(rightCol.expandToFill());
+        bodyLo.doLayout();
     }
 
     layoutModulation(p);
@@ -883,10 +1061,10 @@ void SourceSubPanel::setExtendedModeVisibility()
 
     auto isPhaseRemap = (em == EM::PHASE_REMAP);
     auto isResonantSweep = (em == EM::RESONANT_SWEEP);
-    auto isComing = (em == EM::REDACTED_1);
-    auto showsM = isPhaseRemap || isResonantSweep;
+    auto isPinkNoise = (em == EM::PINK_NOISE);
+    auto showsM = isPhaseRemap || isResonantSweep || isPinkNoise;
 
-    comingSoonLabel->setVisible(isComing);
+    comingSoonLabel->setVisible(false);
     phaseMapShape->setVisible(isPhaseRemap);
     extM->setVisible(showsM);
     extML->setVisible(showsM);
@@ -901,6 +1079,10 @@ void SourceSubPanel::setExtendedModeVisibility()
     resonantSweepDepthL->setVisible(isResonantSweep);
     if (resSweepPainter)
         resSweepPainter->setVisible(isResonantSweep);
+    if (pinkNoiseMode)
+        pinkNoiseMode->setVisible(isPinkNoise);
+    if (pinkNoisePainter)
+        pinkNoisePainter->setVisible(isPinkNoise);
 }
 
 void SourceSubPanel::setEnabledState()
@@ -952,6 +1134,8 @@ void SourceSubPanel::setEnabledState()
     extM->setEnabled(!isAudioIn);
     envToExtM->setEnabled(!isAudioIn);
     lfoToExtM->setEnabled(!isAudioIn);
+    if (pinkNoiseMode)
+        pinkNoiseMode->setEnabled(!isAudioIn);
 
     // Notify source/matrix panels to grey out ratio knob and feedback knob
     editor.sourcePanel->updateOpEnabledState(index);

--- a/src/ui/source-sub-panel.h
+++ b/src/ui/source-sub-panel.h
@@ -100,6 +100,11 @@ struct SourceSubPanel : juce::Component,
     std::unique_ptr<jcmp::Label> resonantSweepDepthL;
     std::unique_ptr<juce::Component> resSweepPainter;
 
+    // Pink-noise body components
+    std::unique_ptr<jcmp::MultiSwitch> pinkNoiseMode;
+    std::unique_ptr<PatchDiscrete> pinkNoiseModeD;
+    std::unique_ptr<juce::Component> pinkNoisePainter;
+
     void setExtendedModeVisibility();
 
     std::unique_ptr<jcmp::HSliderFilled> keyTrackValue;


### PR DESCRIPTION
A new source-operator extended mode that injects pink noise via one of four mix paths: add to phase, add to signal, mix with signal, or multiply by signal. Includes M, Env->M, LFO->M depth controls and a fixed-seed visualiser of the resulting waveform.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>