### PR TITLE
Rename pink-noise extended mode to "Noise" and add Noise Type selector

### DIFF
--- a/src/dsp/op_source.h
+++ b/src/dsp/op_source.h
@@ -118,7 +118,7 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
             using EM = Patch::SourceNode::ExtendedMode;
             auto em = static_cast<EM>(
                 static_cast<uint32_t>(std::round(sourceNode.extendedModeMode.value)));
-            if (em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP || em == EM::PINK_NOISE)
+            if (em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP || em == EM::NOISE)
             {
                 extendedLagM.setRateInMilliseconds(10, monoValues.sr.samplerate, blockSizeInv);
                 extendedLagM.snapTo(sourceNode.extendedModeM.value);
@@ -194,7 +194,7 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
         using EM = Patch::SourceNode::ExtendedMode;
         auto em =
             static_cast<EM>(static_cast<uint32_t>(std::round(sourceNode.extendedModeMode.value)));
-        if (em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP || em == EM::PINK_NOISE)
+        if (em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP || em == EM::NOISE)
             used = used || (sourceNode.lfoToExtendedModeM.value != 0);
 
         return used;
@@ -443,30 +443,27 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
             }
             break;
         }
-        case EM::PINK_NOISE:
+        case EM::NOISE:
         {
             using NM = Patch::SourceNode::NoiseMode;
             auto nm =
-                static_cast<NM>(static_cast<uint32_t>(std::round(sourceNode.pinkNoiseMode.value)));
+                static_cast<NM>(static_cast<uint32_t>(std::round(sourceNode.noiseMode.value)));
             constexpr auto PMSAW = Patch::SourceNode::PhaseMapShape::SAW;
             constexpr auto RWSAW = Patch::SourceNode::ResonantSweepWindow::SAW;
             switch (nm)
             {
             case NM::ADD_TO_PHASE:
-                innerLoopImpl<EM::PINK_NOISE, PMSAW, RWSAW, NM::ADD_TO_PHASE>(onto, fbv, rf, dRF,
-                                                                              phs);
+                innerLoopImpl<EM::NOISE, PMSAW, RWSAW, NM::ADD_TO_PHASE>(onto, fbv, rf, dRF, phs);
                 break;
             case NM::ADD_TO_SIGNAL:
-                innerLoopImpl<EM::PINK_NOISE, PMSAW, RWSAW, NM::ADD_TO_SIGNAL>(onto, fbv, rf, dRF,
-                                                                               phs);
+                innerLoopImpl<EM::NOISE, PMSAW, RWSAW, NM::ADD_TO_SIGNAL>(onto, fbv, rf, dRF, phs);
                 break;
             case NM::MIX_WITH_SIGNAL:
-                innerLoopImpl<EM::PINK_NOISE, PMSAW, RWSAW, NM::MIX_WITH_SIGNAL>(onto, fbv, rf, dRF,
-                                                                                 phs);
+                innerLoopImpl<EM::NOISE, PMSAW, RWSAW, NM::MIX_WITH_SIGNAL>(onto, fbv, rf, dRF,
+                                                                            phs);
                 break;
             case NM::MUL_BY_SIGNAL:
-                innerLoopImpl<EM::PINK_NOISE, PMSAW, RWSAW, NM::MUL_BY_SIGNAL>(onto, fbv, rf, dRF,
-                                                                               phs);
+                innerLoopImpl<EM::NOISE, PMSAW, RWSAW, NM::MUL_BY_SIGNAL>(onto, fbv, rf, dRF, phs);
                 break;
             }
             break;
@@ -485,7 +482,7 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
         using EM = Patch::SourceNode::ExtendedMode;
         using NMode = Patch::SourceNode::NoiseMode;
         float nextM{0.f}, dM{0.f};
-        if constexpr (ET == EM::PHASE_REMAP || ET == EM::RESONANT_SWEEP || ET == EM::PINK_NOISE)
+        if constexpr (ET == EM::PHASE_REMAP || ET == EM::RESONANT_SWEEP || ET == EM::NOISE)
         {
             // Raw target m for this block: patch value + external mod + env / lfo contributions.
             auto lfoFac = *lfoFacP;
@@ -560,20 +557,20 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
                 nextM += dM;
                 out = window * st.at(kmph);
             }
-            else if constexpr (ET == EM::PINK_NOISE)
+            else if constexpr (ET == EM::NOISE)
             {
                 if (noisePos >= 16)
                 {
                     pinkNoise.generate16(noiseBuf);
                     noisePos = 0;
                 }
-                float noise = noiseBuf[noisePos++] * Patch::SourceNode::pinkNoiseScale;
+                float noise = noiseBuf[noisePos++] * Patch::SourceNode::noiseScale;
                 float m = nextM;
                 nextM += dM;
                 if constexpr (NM == NMode::ADD_TO_PHASE)
                 {
                     ph += static_cast<int32_t>(m * noise * phase::phaseMaxF *
-                                               Patch::SourceNode::pinkNoisePhaseScale);
+                                               Patch::SourceNode::noisePhaseScale);
                     out = st.at(ph);
                 }
                 else if constexpr (NM == NMode::ADD_TO_SIGNAL)

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -524,7 +524,7 @@ struct Patch : pats::PatchBase<Patch, Param>
             NONE = 0,           // these value stream
             PHASE_REMAP = 1,    // CZ-style wave 1-4 wav(phase) -> wav(map(phase))
             RESONANT_SWEEP = 2, // CZ-style resonant sweep (5-9)
-            PINK_NOISE = 3      // pink noise injection
+            NOISE = 3           // noise injection
         };
 
         enum struct NoiseMode : uint32_t
@@ -535,11 +535,19 @@ struct Patch : pats::PatchBase<Patch, Param>
             MUL_BY_SIGNAL = 3,
         };
 
-        // Pink noise from PinkNoise.generate16 has roughly ±0.25 typical amplitude;
+        enum struct NoiseType : uint32_t
+        {
+            WHITE = 0,
+            PINK = 1,
+            TILT = 2,
+            CHIP_LFSR = 3,
+        };
+
+        // Noise from PinkNoise.generate16 has roughly ±0.25 typical amplitude;
         // scale up so M=1 reaches a useful range. ADD_TO_PHASE additionally needs
         // attenuation since one full cycle of phase jitter is too much.
-        static constexpr float pinkNoiseScale = 4.0f;
-        static constexpr float pinkNoisePhaseScale = 0.1f;
+        static constexpr float noiseScale = 3.0f;
+        static constexpr float noisePhaseScale = 0.1f;
 
         enum struct PhaseMapShape : uint32_t
         {
@@ -744,7 +752,7 @@ struct Patch : pats::PatchBase<Patch, Param>
                                        {(int)ExtendedMode::NONE, "None"},
                                        {(int)ExtendedMode::PHASE_REMAP, "Phase Map"},
                                        {(int)ExtendedMode::RESONANT_SWEEP, "Resonant Sweep"},
-                                       {(int)ExtendedMode::PINK_NOISE, "Pink Noise"},
+                                       {(int)ExtendedMode::NOISE, "Noise"},
                                    })),
               extendedModeM(floatMd(version_120b)
                                 .asPercent()
@@ -823,18 +831,30 @@ struct Patch : pats::PatchBase<Patch, Param>
                                                   {(int)ResonantSweepFrequencyDepth::FOUR, "4 oct"},
                                                   {(int)ResonantSweepFrequencyDepth::TEN, "10 oct"},
                                               })),
-              pinkNoiseMode(intMd(version_120f)
-                                .withRange(0, 3)
-                                .withDefault(0)
-                                .withID(id(185, idx))
-                                .withName(name(idx) + " Pink Noise Mode")
-                                .withGroupName(name(idx))
-                                .withUnorderedMapFormatting({
-                                    {(int)NoiseMode::ADD_TO_PHASE, "Add to Phase"},
-                                    {(int)NoiseMode::ADD_TO_SIGNAL, "Add to Signal"},
-                                    {(int)NoiseMode::MIX_WITH_SIGNAL, "Mix"},
-                                    {(int)NoiseMode::MUL_BY_SIGNAL, "Mul by Signal"},
-                                }))
+              noiseMode(intMd(version_120f)
+                            .withRange(0, 3)
+                            .withDefault(0)
+                            .withID(id(185, idx))
+                            .withName(name(idx) + " Noise Mode")
+                            .withGroupName(name(idx))
+                            .withUnorderedMapFormatting({
+                                {(int)NoiseMode::ADD_TO_PHASE, "Add to Phase"},
+                                {(int)NoiseMode::ADD_TO_SIGNAL, "Add to Signal"},
+                                {(int)NoiseMode::MIX_WITH_SIGNAL, "Mix"},
+                                {(int)NoiseMode::MUL_BY_SIGNAL, "Mul by Signal"},
+                            })),
+              noiseType(intMd(version_120f)
+                            .withRange(0, 3)
+                            .withDefault((int)NoiseType::PINK)
+                            .withID(id(186, idx))
+                            .withName(name(idx) + " Noise Type")
+                            .withGroupName(name(idx))
+                            .withUnorderedMapFormatting({
+                                {(int)NoiseType::WHITE, "White"},
+                                {(int)NoiseType::PINK, "Pink"},
+                                {(int)NoiseType::TILT, "Tilt"},
+                                {(int)NoiseType::CHIP_LFSR, "Chip LFSR"},
+                            }))
 
         {
             index = idx;
@@ -877,7 +897,8 @@ struct Patch : pats::PatchBase<Patch, Param>
         Param phaseMapModeShape;
         Param resonantSweepWindowShape;
         Param resonantSweepFrequencyDepth;
-        Param pinkNoiseMode;
+        Param noiseMode;
+        Param noiseType;
 
         std::array<Param, numModsPer> modtarget;
 
@@ -909,7 +930,8 @@ struct Patch : pats::PatchBase<Patch, Param>
                                      &phaseMapModeShape,
                                      &resonantSweepWindowShape,
                                      &resonantSweepFrequencyDepth,
-                                     &pinkNoiseMode};
+                                     &noiseMode,
+                                     &noiseType};
             for (int i = 0; i < numModsPer; ++i)
                 res.push_back(&modtarget[i]);
             appendDAHDSRParams(res);

--- a/src/ui/source-sub-panel.cpp
+++ b/src/ui/source-sub-panel.cpp
@@ -403,22 +403,22 @@ struct ResSweepPlotter : juce::Component
 };
 
 /*
- * PinkNoisePainter shows the result of applying the active NoiseMode to the current
+ * NoisePainter shows the result of applying the active NoiseMode to the current
  * waveform with a fixed-seed pink noise source so the picture is reproducible. We
  * draw the underlying waveform faintly behind, the noise sequence dotted, and the
  * combined result on top.
  */
-struct PinkNoisePainter : juce::Component
+struct NoisePainter : juce::Component
 {
     const Param &wf, &ph, &mp, &noiseMode;
     SixSinesEditor &editor;
     SinTable st;
 
-    static constexpr int numCycles{2};
+    static constexpr int numCycles{1};
     static constexpr uint32_t fixedSeed{0xDEC0DE42u};
 
-    PinkNoisePainter(const Param &w, const Param &p, const Param &mParam, const Param &nMode,
-                     SixSinesEditor &e)
+    NoisePainter(const Param &w, const Param &p, const Param &mParam, const Param &nMode,
+                 SixSinesEditor &e)
         : wf(w), ph(p), mp(mParam), noiseMode(nMode), editor(e)
     {
     }
@@ -487,7 +487,7 @@ struct PinkNoisePainter : juce::Component
                 rng.generate16(noiseBuf);
                 noisePos = 0;
             }
-            float n = noiseBuf[noisePos++] * Patch::SourceNode::pinkNoiseScale;
+            float n = noiseBuf[noisePos++] * Patch::SourceNode::noiseScale;
             float base = st.at(wph);
             float out;
             uint32_t modPh = wph;
@@ -496,7 +496,7 @@ struct PinkNoisePainter : juce::Component
             {
             case NM::ADD_TO_PHASE:
                 modPh = (wph + static_cast<int32_t>(m * n * phase::phaseMaxF *
-                                                    Patch::SourceNode::pinkNoisePhaseScale)) &
+                                                    Patch::SourceNode::noisePhaseScale)) &
                         phase::phaseMask;
                 out = st.at(modPh);
                 break;
@@ -546,9 +546,9 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
         auto em = static_cast<EM>(static_cast<int>(
             std::round(w->editor.patchCopy.sourceNodes[w->index].extendedModeMode.value)));
         if (tid == TID::EXTEND_M)
-            return em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP || em == EM::PINK_NOISE;
+            return em == EM::PHASE_REMAP || em == EM::RESONANT_SWEEP || em == EM::NOISE;
         if (tid == TID::EXTEND_N)
-            return false;
+            return em == EM::NOISE;
         return true;
     };
 
@@ -607,8 +607,8 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
             pdWavPainter->repaint();
         if (resSweepPainter)
             resSweepPainter->repaint();
-        if (pinkNoisePainter)
-            pinkNoisePainter->repaint();
+        if (noisePainter)
+            noisePainter->repaint();
         wavButton->repaint();
         setEnabledState();
     };
@@ -631,8 +631,8 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
             w->pdWavPainter->repaint();
         if (w->resSweepPainter)
             w->resSweepPainter->repaint();
-        if (w->pinkNoisePainter)
-            w->pinkNoisePainter->repaint();
+        if (w->noisePainter)
+            w->noisePainter->repaint();
     };
 
     startingPhaseL = std::make_unique<jcmp::Label>();
@@ -743,6 +743,27 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
     lfoToExtML->setText(std::string() + "LFO" + u8"\U00002192" + "M");
     addChildComponent(*lfoToExtML);
 
+    createComponent(editor, *this, sn.extendedModeN, extN, extND);
+    addChildComponent(*extN);
+    traverse(extN);
+    extNL = std::make_unique<jcmp::Label>();
+    extNL->setText("N");
+    addChildComponent(*extNL);
+
+    createComponent(editor, *this, sn.envToExtendedModeN, envToExtN, envToExtND);
+    addChildComponent(*envToExtN);
+    traverse(envToExtN);
+    envToExtNL = std::make_unique<jcmp::Label>();
+    envToExtNL->setText(std::string() + "Env" + u8"\U00002192" + "N");
+    addChildComponent(*envToExtNL);
+
+    createComponent(editor, *this, sn.lfoToExtendedModeN, lfoToExtN, lfoToExtND);
+    addChildComponent(*lfoToExtN);
+    traverse(lfoToExtN);
+    lfoToExtNL = std::make_unique<jcmp::Label>();
+    lfoToExtNL->setText(std::string() + "LFO" + u8"\U00002192" + "N");
+    addChildComponent(*lfoToExtNL);
+
     pdWavPainter = std::make_unique<PDWavPainter>(sn.waveForm, sn.startingPhase, sn.extendedModeM,
                                                   sn.phaseMapModeShape, editor);
     addChildComponent(*pdWavPainter);
@@ -765,13 +786,23 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
         sn.resonantSweepFrequencyDepth, editor);
     addChildComponent(*resSweepPainter);
 
-    createComponent(editor, *this, sn.pinkNoiseMode, pinkNoiseMode, pinkNoiseModeD);
-    addChildComponent(*pinkNoiseMode);
-    traverse(pinkNoiseMode);
+    createComponent(editor, *this, sn.noiseMode, noiseMode, noiseModeD);
+    addChildComponent(*noiseMode);
+    traverse(noiseMode);
+    noiseModeL = std::make_unique<jcmp::Label>();
+    noiseModeL->setText("Mode");
+    addChildComponent(*noiseModeL);
 
-    pinkNoisePainter = std::make_unique<PinkNoisePainter>(
-        sn.waveForm, sn.startingPhase, sn.extendedModeM, sn.pinkNoiseMode, editor);
-    addChildComponent(*pinkNoisePainter);
+    createComponent(editor, *this, sn.noiseType, noiseType, noiseTypeD);
+    addChildComponent(*noiseType);
+    traverse(noiseType);
+    noiseTypeL = std::make_unique<jcmp::Label>();
+    noiseTypeL->setText("Type");
+    addChildComponent(*noiseTypeL);
+
+    noisePainter = std::make_unique<NoisePainter>(sn.waveForm, sn.startingPhase, sn.extendedModeM,
+                                                  sn.noiseMode, editor);
+    addChildComponent(*noisePainter);
 
     // Live-repaint extended-mode painters when any of their inputs change.
     auto repaintExt = [w = juce::Component::SafePointer(this)]()
@@ -782,19 +813,27 @@ void SourceSubPanel::setSelectedIndex(size_t idx)
             w->pdWavPainter->repaint();
         if (w->resSweepPainter)
             w->resSweepPainter->repaint();
-        if (w->pinkNoisePainter)
-            w->pinkNoisePainter->repaint();
+        if (w->noisePainter)
+            w->noisePainter->repaint();
     };
     extMD->onGuiSetValue = repaintExt;
     phaseMapShapeD->onGuiSetValue = repaintExt;
     resonantWindowShapeD->onGuiSetValue = repaintExt;
     resonantSweepDepthD->onGuiSetValue = repaintExt;
-    pinkNoiseModeD->onGuiSetValue = repaintExt;
+    noiseModeD->onGuiSetValue = repaintExt;
+    auto noiseTypeChanged = [w = juce::Component::SafePointer(this)]()
+    {
+        if (!w)
+            return;
+        w->setEnabledState();
+    };
+    noiseTypeD->onGuiSetValue = noiseTypeChanged;
     editor.componentRefreshByID[sn.extendedModeM.meta.id] = repaintExt;
     editor.componentRefreshByID[sn.phaseMapModeShape.meta.id] = repaintExt;
     editor.componentRefreshByID[sn.resonantSweepWindowShape.meta.id] = repaintExt;
     editor.componentRefreshByID[sn.resonantSweepFrequencyDepth.meta.id] = repaintExt;
-    editor.componentRefreshByID[sn.pinkNoiseMode.meta.id] = repaintExt;
+    editor.componentRefreshByID[sn.noiseMode.meta.id] = repaintExt;
+    editor.componentRefreshByID[sn.noiseType.meta.id] = noiseTypeChanged;
 
     setExtendedModeVisibility();
 
@@ -1007,15 +1046,18 @@ void SourceSubPanel::resized()
         bodyLo.add(rightCol.expandToFill());
         bodyLo.doLayout();
     }
-    else if (em == EM::PINK_NOISE)
+    else if (em == EM::NOISE)
     {
-        // Layout mirrors RESONANT_SWEEP:
-        //   [ noise-mode multi ] [ pink-noise painter spans                ]
-        //   [ noise-mode multi ] [ M ] [ Env->M ] [ LFO->M ]
-        constexpr int plotHeight = painterH - 15;
+        // Layout:
+        //   [ Mode : [ jog ] ]  [ noise painter spans       ]
+        //   [ Type : [ jog ] ]  [ noise painter spans       ]
+        //   [ M ] [ Env->M ] [ LFO->M ] [ N ] [ Env->N ] [ LFO->N ]
         constexpr int cellW = uicKnobSize;
         constexpr int row2H = uicLabeledKnobHeight;
+        constexpr int plotHeight = painterH - 15;
         constexpr int bodyH = plotHeight + uicMargin + row2H;
+        constexpr int leftColW = (cellW * 8) / 2;
+        constexpr int leftLabelW = 44;
         auto bodyRect = juce::Rectangle<int>(depx, bodyY, p.getWidth(), bodyH);
 
         auto knobCell = [](auto &k, auto &l)
@@ -1025,30 +1067,44 @@ void SourceSubPanel::resized()
             return cell;
         };
 
-        auto bodyLo = jlo::HList()
-                          .at(bodyRect.getX(), bodyRect.getY())
+        // Top section: left controls column + plot
+        auto topLo = jlo::HList()
+                         .at(bodyRect.getX(), bodyRect.getY())
+                         .withWidth(bodyRect.getWidth())
+                         .withHeight(plotHeight)
+                         .withAutoGap(uicMargin * 2);
+
+        auto labelJogRow = [](auto &lab, auto &jog)
+        {
+            auto row = jlo::HList().withHeight(uicLabelHeight).withAutoGap(uicMargin);
+            row.add(jlo::Component(lab).withWidth(leftLabelW));
+            row.add(jlo::Component(jog).expandToFill());
+            return row;
+        };
+
+        auto leftStack = jlo::VList().withAutoGap(uicMargin);
+        leftStack.add(labelJogRow(*noiseModeL, *noiseMode));
+        leftStack.add(labelJogRow(*noiseTypeL, *noiseType));
+        auto leftCol = jlo::VList().withWidth(leftColW);
+        leftCol.add(leftStack.centerInParent());
+        topLo.add(leftCol);
+
+        topLo.add(jlo::Component(*noisePainter).withHeight(plotHeight).expandToFill());
+        topLo.doLayout();
+
+        // Knob row: M / Env->M / LFO->M / N / Env->N / LFO->N across the body width.
+        auto knobLo = jlo::HList()
+                          .at(bodyRect.getX(), bodyRect.getY() + plotHeight + uicMargin * 2)
                           .withWidth(bodyRect.getWidth())
-                          .withHeight(bodyRect.getHeight())
-                          .withAutoGap(uicMargin * 2);
-
-        // Left: multiswitch spans full body height
-        auto leftCol = jlo::VList().withWidth(2 * cellW);
-        leftCol.add(jlo::Component(*pinkNoiseMode).withHeight(bodyH));
-        bodyLo.add(leftCol);
-
-        // Right: painter on top, then M / Env->M / LFO->M
-        auto rightCol = jlo::VList().withAutoGap(uicMargin);
-        rightCol.add(jlo::Component(*pinkNoisePainter).withHeight(plotHeight));
-
-        auto knobRow = jlo::HList().withHeight(row2H).withAutoGap(uicMargin);
-        knobRow.add(knobCell(extM, extML));
-        knobRow.add(knobCell(envToExtM, envToExtML));
-        knobRow.add(knobCell(lfoToExtM, lfoToExtML));
-        rightCol.addGap(uicMargin);
-        rightCol.add(knobRow);
-
-        bodyLo.add(rightCol.expandToFill());
-        bodyLo.doLayout();
+                          .withHeight(row2H)
+                          .withAutoGap(uicMargin);
+        knobLo.add(knobCell(extM, extML).centerInParent().expandToFill());
+        knobLo.add(knobCell(envToExtM, envToExtML).centerInParent().expandToFill());
+        knobLo.add(knobCell(lfoToExtM, lfoToExtML).centerInParent().expandToFill());
+        knobLo.add(knobCell(extN, extNL).centerInParent().expandToFill());
+        knobLo.add(knobCell(envToExtN, envToExtNL).centerInParent().expandToFill());
+        knobLo.add(knobCell(lfoToExtN, lfoToExtNL).centerInParent().expandToFill());
+        knobLo.doLayout();
     }
 
     layoutModulation(p);
@@ -1061,8 +1117,8 @@ void SourceSubPanel::setExtendedModeVisibility()
 
     auto isPhaseRemap = (em == EM::PHASE_REMAP);
     auto isResonantSweep = (em == EM::RESONANT_SWEEP);
-    auto isPinkNoise = (em == EM::PINK_NOISE);
-    auto showsM = isPhaseRemap || isResonantSweep || isPinkNoise;
+    auto isNoise = (em == EM::NOISE);
+    auto showsM = isPhaseRemap || isResonantSweep || isNoise;
 
     comingSoonLabel->setVisible(false);
     phaseMapShape->setVisible(isPhaseRemap);
@@ -1072,6 +1128,12 @@ void SourceSubPanel::setExtendedModeVisibility()
     envToExtML->setVisible(showsM);
     lfoToExtM->setVisible(showsM);
     lfoToExtML->setVisible(showsM);
+    extN->setVisible(isNoise);
+    extNL->setVisible(isNoise);
+    envToExtN->setVisible(isNoise);
+    envToExtNL->setVisible(isNoise);
+    lfoToExtN->setVisible(isNoise);
+    lfoToExtNL->setVisible(isNoise);
     if (pdWavPainter)
         pdWavPainter->setVisible(isPhaseRemap);
     resonantWindowShape->setVisible(isResonantSweep);
@@ -1079,10 +1141,16 @@ void SourceSubPanel::setExtendedModeVisibility()
     resonantSweepDepthL->setVisible(isResonantSweep);
     if (resSweepPainter)
         resSweepPainter->setVisible(isResonantSweep);
-    if (pinkNoiseMode)
-        pinkNoiseMode->setVisible(isPinkNoise);
-    if (pinkNoisePainter)
-        pinkNoisePainter->setVisible(isPinkNoise);
+    if (noiseMode)
+        noiseMode->setVisible(isNoise);
+    if (noiseModeL)
+        noiseModeL->setVisible(isNoise);
+    if (noiseType)
+        noiseType->setVisible(isNoise);
+    if (noiseTypeL)
+        noiseTypeL->setVisible(isNoise);
+    if (noisePainter)
+        noisePainter->setVisible(isNoise);
 }
 
 void SourceSubPanel::setEnabledState()
@@ -1134,8 +1202,17 @@ void SourceSubPanel::setEnabledState()
     extM->setEnabled(!isAudioIn);
     envToExtM->setEnabled(!isAudioIn);
     lfoToExtM->setEnabled(!isAudioIn);
-    if (pinkNoiseMode)
-        pinkNoiseMode->setEnabled(!isAudioIn);
+    if (noiseMode)
+        noiseMode->setEnabled(!isAudioIn);
+    if (noiseType)
+        noiseType->setEnabled(!isAudioIn);
+
+    using NT = Patch::SourceNode::NoiseType;
+    auto nt = static_cast<NT>(static_cast<int>(std::round(sn.noiseType.value)));
+    auto nKnobsActive = !isAudioIn && (nt == NT::TILT || nt == NT::CHIP_LFSR);
+    extN->setEnabled(nKnobsActive);
+    envToExtN->setEnabled(nKnobsActive);
+    lfoToExtN->setEnabled(nKnobsActive);
 
     // Notify source/matrix panels to grey out ratio knob and feedback knob
     editor.sourcePanel->updateOpEnabledState(index);

--- a/src/ui/source-sub-panel.h
+++ b/src/ui/source-sub-panel.h
@@ -90,6 +90,9 @@ struct SourceSubPanel : juce::Component,
     std::unique_ptr<jcmp::Knob> extM, envToExtM, lfoToExtM;
     std::unique_ptr<PatchContinuous> extMD, envToExtMD, lfoToExtMD;
     std::unique_ptr<jcmp::Label> extML, envToExtML, lfoToExtML;
+    std::unique_ptr<jcmp::Knob> extN, envToExtN, lfoToExtN;
+    std::unique_ptr<PatchContinuous> extND, envToExtND, lfoToExtND;
+    std::unique_ptr<jcmp::Label> extNL, envToExtNL, lfoToExtNL;
     std::unique_ptr<juce::Component> pdWavPainter;
 
     // Resonant sweep body components
@@ -100,10 +103,14 @@ struct SourceSubPanel : juce::Component,
     std::unique_ptr<jcmp::Label> resonantSweepDepthL;
     std::unique_ptr<juce::Component> resSweepPainter;
 
-    // Pink-noise body components
-    std::unique_ptr<jcmp::MultiSwitch> pinkNoiseMode;
-    std::unique_ptr<PatchDiscrete> pinkNoiseModeD;
-    std::unique_ptr<juce::Component> pinkNoisePainter;
+    // Noise body components
+    std::unique_ptr<jcmp::JogUpDownButton> noiseMode;
+    std::unique_ptr<PatchDiscrete> noiseModeD;
+    std::unique_ptr<jcmp::Label> noiseModeL;
+    std::unique_ptr<jcmp::JogUpDownButton> noiseType;
+    std::unique_ptr<PatchDiscrete> noiseTypeD;
+    std::unique_ptr<jcmp::Label> noiseTypeL;
+    std::unique_ptr<juce::Component> noisePainter;
 
     void setExtendedModeVisibility();
 


### PR DESCRIPTION
Renames the PINK_NOISE extended mode to NOISE throughout the enums, UI, and constexpr constants, and lowers the noise scale from 4.0 to 3.0. Adds a new Noise Type parameter (White / Pink / Tilt / Chip LFSR) shown as a jog beneath the application-mode jog in the Noise body, and surfaces the N / Env->N / LFO->N knobs alongside the M row. The N knobs are only active for Tilt and Chip LFSR; Noise Type is a no-op in the DSP for now.

Assisted-By: Claude Opus 4.7