### PR TITLE
Apply structural-param side effects on host automation

### DIFF
--- a/doc/12_roadmap.md
+++ b/doc/12_roadmap.md
@@ -2,10 +2,6 @@
 
 I have a lot of ideas for a '1.2' version of six sines. Not 2.0. Still compatible. But expanded. Here's my rough list
 
-## THings which came in after mostly done
-
-- Reset Controls when automated for clap edge for things like sample rate
-
 ## Modulation
 - Clamp targets
 - LFO -> M etc... depth as an additive and attenuation target

--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -698,26 +698,7 @@ void Synth::processUIQueue(const clap_output_events_t *outq)
                 dest->value = uiM->value;
             }
 
-            /*
-             * Some params have other side effects
-             */
-            if (dest->meta.id == patch.output.playMode.meta.id ||
-                dest->meta.id == patch.output.polyLimit.meta.id ||
-                dest->meta.id == patch.output.pianoModeActive.meta.id ||
-                dest->meta.id == patch.output.mpeActive.meta.id ||
-                dest->meta.id == patch.output.sampleRateStrategy.meta.id ||
-                dest->meta.id == patch.output.resampleEngine.meta.id ||
-                dest->meta.id == patch.output.lowpass.meta.id ||
-                dest->meta.id == patch.output.highpass.meta.id ||
-                dest->meta.id == patch.output.bitRateAdjust.meta.id)
-            {
-                reapplyControlSettings();
-            }
-
-            if (dest->adhocFeatures & Param::AdHocFeatureValues::SOLO)
-            {
-                resetSoloState();
-            }
+            handleAudioThreadParamSideEffects(dest);
 
             auto d = patch.dirty;
             if (!d)
@@ -1075,12 +1056,43 @@ void Synth::handleParamValue(Param *p, uint32_t pid, float value)
         p = patch.paramMap.at(pid);
     }
 
-    // p->value = value;
-    p->lag.setTarget(value);
-    paramLagSet.addToActive(p);
+    // Mirror the UI path (SET_PARAM): only FLOATs lag; discrete params snap so
+    // that handleAudioThreadParamSideEffects sees the new value, not the old.
+    if (p->meta.type == md_t::FLOAT)
+    {
+        p->lag.setTarget(value);
+        paramLagSet.addToActive(p);
+    }
+    else
+    {
+        p->value = value;
+    }
+
+    handleAudioThreadParamSideEffects(p);
 
     AudioToUIMsg au = {AudioToUIMsg::UPDATE_PARAM, pid, value};
     audioToUi.push(au);
+}
+
+void Synth::handleAudioThreadParamSideEffects(Param *dest)
+{
+    if (dest->meta.id == patch.output.playMode.meta.id ||
+        dest->meta.id == patch.output.polyLimit.meta.id ||
+        dest->meta.id == patch.output.pianoModeActive.meta.id ||
+        dest->meta.id == patch.output.mpeActive.meta.id ||
+        dest->meta.id == patch.output.sampleRateStrategy.meta.id ||
+        dest->meta.id == patch.output.resampleEngine.meta.id ||
+        dest->meta.id == patch.output.lowpass.meta.id ||
+        dest->meta.id == patch.output.highpass.meta.id ||
+        dest->meta.id == patch.output.bitRateAdjust.meta.id)
+    {
+        reapplyControlSettings();
+    }
+
+    if (dest->adhocFeatures & Param::AdHocFeatureValues::SOLO)
+    {
+        resetSoloState();
+    }
 }
 
 void Synth::pushFullUIRefresh()

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -522,6 +522,7 @@ struct Synth
 
     void reapplyControlSettings();
     void resetSoloState();
+    void handleAudioThreadParamSideEffects(Param *dest);
 
     sst::cpputils::active_set_overlay<Param> paramLagSet;
 


### PR DESCRIPTION
Audio-thread CLAP param events updated the param value but skipped the reapplyControlSettings / resetSoloState dispatch that the UI path runs, so automating play mode, polyphony, MPE, sample rate strategy, the output filters, bit rate, or solo silently failed to reconfigure the engine. Extract the side-effect block into handleAudioThreadParamSideEffects and call it from both the UI message path and the CLAP event path. Match the UI path's int-vs-float discipline so discrete params snap before the side-effect call sees them.

Assisted-By: Claude Opus 4.7