### PR TITLE
Default the spectrum and color editor windows to always-on-top

### DIFF
--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -48,6 +48,7 @@ CMRC_DECLARE(sixsines_fonts);
 #include "spectrum-analyzer.h"
 #include <sst/jucegui/components/GlyphButton.h>
 #include <sst/jucegui/components/ButtonPainter.h>
+#include <sst/jucegui/component-adapters/DiscreteToReference.h>
 #include "macro-sub-panel.h"
 #include "clipboard.h"
 #include "patch-data-bindings.h"
@@ -1883,6 +1884,12 @@ void SixSinesEditor::openColorEditor()
         std::unique_ptr<jscr::ColorEditor> colorEditor;
         std::unique_ptr<jcmp::TextPushButton> saveBtn, loadBtn, factoryBtn;
 
+        bool alwaysOnTopState{true};
+        std::unique_ptr<
+            sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::ToggleButton, bool>>
+            alwaysOnTopAdapter;
+        std::function<void(bool)> onAlwaysOnTopChanged;
+
         ColorEditorContent(std::unique_ptr<jscr::ColorEditor> ce,
                            std::unique_ptr<jcmp::TextPushButton> sb,
                            std::unique_ptr<jcmp::TextPushButton> lb,
@@ -1895,6 +1902,21 @@ void SixSinesEditor::openColorEditor()
             addAndMakeVisible(*saveBtn);
             addAndMakeVisible(*loadBtn);
             addAndMakeVisible(*factoryBtn);
+
+            alwaysOnTopAdapter =
+                std::make_unique<sst::jucegui::component_adapters::DiscreteToValueReference<
+                    jcmp::ToggleButton, bool>>(alwaysOnTopState);
+            auto *btn = alwaysOnTopAdapter->widget.get();
+            btn->setGlyph(jcmp::GlyphPainter::PIN);
+            btn->setOffGlyph(jcmp::GlyphPainter::UNPIN);
+            btn->setTitle("Always on Top");
+            addAndMakeVisible(*btn);
+            alwaysOnTopAdapter->onValueChanged = [this](bool b)
+            {
+                if (onAlwaysOnTopChanged)
+                    onAlwaysOnTopChanged(b);
+            };
+
             // setStyle propagates recursively to all StyleConsumer children.
             setStyle(ss);
         }
@@ -1905,6 +1927,10 @@ void SixSinesEditor::openColorEditor()
             auto strip = b.removeFromBottom(34);
             colorEditor->setBounds(b);
             strip = strip.reduced(6, 3);
+            // Always-on-top toggle on the right edge of the button strip.
+            auto pinSz = strip.getHeight();
+            alwaysOnTopAdapter->widget->setBounds(strip.removeFromRight(pinSz));
+            strip.removeFromRight(6);
             saveBtn->setBounds(strip.removeFromLeft(120));
             strip.removeFromLeft(6);
             loadBtn->setBounds(strip.removeFromLeft(120));
@@ -1921,6 +1947,11 @@ void SixSinesEditor::openColorEditor()
         {
             setUsingNativeTitleBar(true);
             setResizable(true, false);
+            // Default on-top so hosts (e.g. Reaper) that pin the plugin window above
+            // peers don't bury this. The pin toggle in the button strip lets the user
+            // opt out per session.
+            setAlwaysOnTop(true);
+            content->onAlwaysOnTopChanged = [this](bool b) { setAlwaysOnTop(b); };
             setContentOwned(content.release(), true);
             setSize(420, 560);
         }

--- a/src/ui/spectrum-analyzer.cpp
+++ b/src/ui/spectrum-analyzer.cpp
@@ -19,8 +19,13 @@
 #include <chrono>
 #include <cmath>
 
+#include <sst/jucegui/components/GlyphPainter.h>
+#include <sst/jucegui/style/StyleSheet.h>
+
 namespace baconpaul::six_sines::ui
 {
+
+namespace jcmp = sst::jucegui::components;
 
 namespace
 {
@@ -64,6 +69,25 @@ SpectrumAnalyzerComponent::SpectrumAnalyzerComponent(Synth::audioOutputQueue_t &
     if (hostSr > 0.f)
         hostSampleRate = hostSr;
     setOpaque(true);
+
+    alwaysOnTopAdapter = std::make_unique<
+        sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::ToggleButton, bool>>(
+        alwaysOnTopState);
+    auto *btn = alwaysOnTopAdapter->widget.get();
+    btn->setGlyph(jcmp::GlyphPainter::PIN);
+    btn->setOffGlyph(jcmp::GlyphPainter::UNPIN);
+    btn->setTitle("Always on Top");
+    addAndMakeVisible(*btn);
+    alwaysOnTopAdapter->onValueChanged = [this](bool b)
+    {
+        if (onAlwaysOnTopChanged)
+            onAlwaysOnTopChanged(b);
+    };
+
+    setStyle(sst::jucegui::style::StyleSheet::getBuiltInStyleSheet(
+        sst::jucegui::style::StyleSheet::DARK));
+
+    // setSize last so the resulting resized() positions the toggle.
     setSize(720, 690);
 
     int savedMode = defaultModeIdx;
@@ -103,7 +127,15 @@ SpectrumAnalyzerComponent::~SpectrumAnalyzerComponent()
     ring.clear();
 }
 
-void SpectrumAnalyzerComponent::resized() {}
+void SpectrumAnalyzerComponent::resized()
+{
+    if (alwaysOnTopAdapter)
+    {
+        constexpr int sz = 20;
+        constexpr int pad = 4;
+        alwaysOnTopAdapter->widget->setBounds(getWidth() - sz - pad, pad, sz, sz);
+    }
+}
 
 void SpectrumAnalyzerComponent::mouseDown(const juce::MouseEvent &e)
 {
@@ -587,6 +619,11 @@ SpectrumAnalyzerWindow::SpectrumAnalyzerWindow(std::unique_ptr<SpectrumAnalyzerC
 {
     setUsingNativeTitleBar(true);
     setResizable(true, false);
+    // Default on-top so the window isn't hidden by hosts (e.g. Reaper) that pin the
+    // plugin window above all peers. The toggle in the component's upper-right lets
+    // the user opt out per session.
+    setAlwaysOnTop(true);
+    content->onAlwaysOnTopChanged = [this](bool b) { setAlwaysOnTop(b); };
     setContentOwned(content.release(), true);
     setSize(720, 690);
 }

--- a/src/ui/spectrum-analyzer.h
+++ b/src/ui/spectrum-analyzer.h
@@ -27,13 +27,17 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <juce_dsp/juce_dsp.h>
 
+#include <sst/jucegui/components/WindowPanel.h>
+#include <sst/jucegui/components/ToggleButton.h>
+#include <sst/jucegui/component-adapters/DiscreteToReference.h>
+
 #include "synth/synth.h"
 #include "ui-defaults.h"
 
 namespace baconpaul::six_sines::ui
 {
 
-struct SpectrumAnalyzerComponent : juce::Component, private juce::AsyncUpdater
+struct SpectrumAnalyzerComponent : sst::jucegui::components::WindowPanel, private juce::AsyncUpdater
 {
     static constexpr int spectrogramColumns = 256;
 
@@ -64,6 +68,9 @@ struct SpectrumAnalyzerComponent : juce::Component, private juce::AsyncUpdater
 
     // Pushed by the editor when the host sample rate changes; rebuilds buffers if needed.
     void setHostSampleRate(float sr);
+
+    // Fired by the always-on-top toggle. The window wires this to setAlwaysOnTop().
+    std::function<void(bool)> onAlwaysOnTopChanged;
 
   private:
     void handleAsyncUpdate() override;
@@ -131,6 +138,13 @@ struct SpectrumAnalyzerComponent : juce::Component, private juce::AsyncUpdater
 
     std::thread analysisThread;
     std::atomic<bool> running{false};
+
+    // Always-on-top toggle. Declared after `alwaysOnTopState` so the adapter (and its
+    // owned widget) is destroyed before the bool it references.
+    bool alwaysOnTopState{true};
+    std::unique_ptr<sst::jucegui::component_adapters::DiscreteToValueReference<
+        sst::jucegui::components::ToggleButton, bool>>
+        alwaysOnTopAdapter;
 };
 
 struct SpectrumAnalyzerWindow : juce::DocumentWindow


### PR DESCRIPTION
Add a pin/unpin toggle to each window so the user can opt out per session. Hosts like Reaper pin the plugin window above all peers, which would otherwise hide these floating windows.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>