### PR TITLE
User patch save quality-of-life improvements

### DIFF
--- a/doc/12_roadmap.md
+++ b/doc/12_roadmap.md
@@ -31,8 +31,6 @@ to add new test files to tests/CMakeLists.txt explicitly. Noted your CLAUDE.md e
 
 ## Smaller Things from the crew
 - djTubig reports patch swapping kinda slow on windows. Look for profile?
-- Refresh patch browser
-
 
 ## Noise Upgrades **DONE**
 - Pink, White, Tilt (with N for tilt) **DONE**

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -712,6 +712,12 @@ void SixSinesEditor::showPresetPopup()
                   if (w)
                       w->startSavePatch();
               });
+    p.addItem("Refresh User Patches",
+              [w = juce::Component::SafePointer(this)]()
+              {
+                  if (w && w->presetManager)
+                      w->presetManager->rescanUserPresets();
+              });
     p.addSeparator();
     std::string ap = "Set Author";
     if (!patchCopy.defaultAuthor.empty())
@@ -966,10 +972,18 @@ void SixSinesEditor::startSavePatch()
 
 void SixSinesEditor::finishSavePatch()
 {
-    auto svP = presetManager->userPatchesPath;
+    auto svDir =
+        lastUserSaveDirectory.empty() ? presetManager->userPatchesPath : lastUserSaveDirectory;
+    auto svP = svDir;
     if (strcmp(patchCopy.name, "Init") != 0)
     {
-        svP = (svP / patchCopy.name).replace_extension(".sxsnp");
+        // append .sxsnp rather than replace_extension: a patch name like
+        // "foo1.2.3.11" would otherwise have ".11" stripped as a fake extension.
+        std::string fn = patchCopy.name;
+        static constexpr std::string_view ext{".sxsnp"};
+        if (fn.size() < ext.size() || fn.compare(fn.size() - ext.size(), ext.size(), ext) != 0)
+            fn += ext;
+        svP = svDir / fn;
     }
     fileChooser =
         std::make_unique<juce::FileChooser>("Save Patch", juce::File(svP.u8string()), "*.sxsnp");
@@ -987,6 +1001,7 @@ void SixSinesEditor::finishSavePatch()
                                  }
                                  auto pn = fs::path{result[0].getFullPathName().toStdString()};
                                  w->setPatchNameTo(pn.filename().replace_extension("").u8string());
+                                 w->lastUserSaveDirectory = pn.parent_path();
 
 #if USE_WCHAR_PRESET
                                  w->presetManager->saveUserPresetDirect(

--- a/src/ui/six-sines-editor.h
+++ b/src/ui/six-sines-editor.h
@@ -138,6 +138,9 @@ struct SixSinesEditor : jcmp::WindowPanel, sst::jucegui::screens::ScreenHolder<S
     void setPatchNameDisplay();
     void setPatchNameTo(const std::string &);
     std::unique_ptr<juce::FileChooser> fileChooser;
+    // Remembers the directory of the most recent save so the next save
+    // dialog opens there. Reset to empty (use default) on editor construction.
+    fs::path lastUserSaveDirectory{};
     std::unique_ptr<juce::DocumentWindow> colorEditorWindow;
     std::unique_ptr<juce::FileChooser> colorThemeFileChooser;
 


### PR DESCRIPTION
- Add a 'Refresh User Patches' item to the patch menu
- Remember the last save directory within a session and reopen the save dialog there
- Fix saving a name like 'foo1.2.3.11' producing 'foo1.2.3.sxsnp': pre-fill the dialog by appending '.sxsnp' instead of replacing the trailing dotted segment

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>