### PR TITLE
Move MPE active and bend range out of the patch onto the engine

### DIFF
--- a/src/synth/mono_values.h
+++ b/src/synth/mono_values.h
@@ -88,6 +88,11 @@ struct MonoValues
     float unisonPanScalar{0.f};
 
     float audioInBlock alignas(16)[blockSize]{}; // engine-rate audio in, mono mix
+
+    // Instance-scoped MPE config — lives on the engine, NOT in the patch. Persisted
+    // via Synth::DawExtraState so DAW sessions round-trip without polluting patches.
+    bool mpeActive{false};
+    int mpeBendRange{24};
 };
 }; // namespace baconpaul::six_sines
 #endif // MONO_VALUES_H

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -74,7 +74,7 @@ struct Param : pats::ParamBase, sst::cpputils::active_set_overlay<Param>::partic
 
 struct Patch : pats::PatchBase<Patch, Param>
 {
-    static constexpr uint32_t patchVersion{9};
+    static constexpr uint32_t patchVersion{10};
     static constexpr const char *id{"org.baconpaul.six-sines"};
 
     static constexpr uint32_t floatFlags{CLAP_PARAM_IS_AUTOMATABLE};
@@ -1669,17 +1669,21 @@ struct Patch : pats::PatchBase<Patch, Param>
                                .withGroupName(name())
                                .withDefault(true)
                                .withID(id(32))),
-              mpeActive(boolMd()
-                            .withName(name() + " MPE Active")
-                            .withGroupName(name())
-                            .withDefault(false)
-                            .withID(id(33))),
-              mpeBendRange(intMd()
-                               .withName(name() + " MPE Bend Range")
-                               .withGroupName(name())
-                               .withRange(1, 96)
-                               .withDefault(24)
-                               .withID(id(34))),
+              // Legacy in 1.1 these stored per-patch MPE config. Now lives on the engine
+              // (MonoValues + DawExtraState). Kept as id-stable slots so 1.1 sessions
+              // still deserialize; the value is only read as a fallback in
+              // Synth::handleSetDawExtraState when the incoming DES has no MPE entries.
+              legacyMpeActive(boolMd()
+                                  .withName(name() + " Unused (was MPE Active)")
+                                  .withGroupName(name())
+                                  .withDefault(false)
+                                  .withID(id(33))),
+              legacyMpeBendRange(intMd()
+                                     .withName(name() + " Unused (was MPE Bend Range)")
+                                     .withGroupName(name())
+                                     .withRange(1, 96)
+                                     .withDefault(24)
+                                     .withID(id(34))),
               octTranspose(intMd()
                                .withName(name() + " Octave Transpose")
                                .withGroupName(name())
@@ -1857,7 +1861,7 @@ struct Patch : pats::PatchBase<Patch, Param>
         Param bendUp, bendDown, polyLimit, defaultTrigger, portaTime, portaContMode,
             pianoModeActive;
         Param unisonCount, unisonSpread, uniPhaseRand, unisonPan;
-        Param mpeActive, mpeBendRange;
+        Param legacyMpeActive, legacyMpeBendRange;
         Param octTranspose, fineTune, pan, lfoDepth;
         Param attackFloorOnRetrig, rephaseOnRetrigger;
         Param sampleRateStrategy, resampleEngine;
@@ -1883,8 +1887,8 @@ struct Patch : pats::PatchBase<Patch, Param>
                                      &unisonSpread,
                                      &unisonPan,
                                      &uniPhaseRand,
-                                     &mpeActive,
-                                     &mpeBendRange,
+                                     &legacyMpeActive,
+                                     &legacyMpeBendRange,
                                      &octTranspose,
                                      &pan,
                                      &fineTune,

--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -99,20 +99,41 @@ void Synth::toDawExtraState(TiXmlElement &e) const
         cm.InsertEndChild(t);
     }
     e.InsertEndChild(cm);
+
+    // Always emit current engine-instance MPE state; this is what flips 1.1→1.2 sessions
+    // to "the new way" once a re-save has happened.
+    TiXmlElement mpe("mpe");
+    mpe.SetAttribute("active", monoValues.mpeActive ? 1 : 0);
+    mpe.SetAttribute("bendRange", monoValues.mpeBendRange);
+    e.InsertEndChild(mpe);
 }
 
 void Synth::fromDawExtraState(TiXmlElement &e, DawExtraState &out)
 {
     out = DawExtraState{};
     auto *cm = e.FirstChildElement("colorMap");
-    if (!cm)
-        return;
-    auto *n = cm->FirstChild();
-    if (n)
+    if (cm)
     {
-        auto *txt = n->ToText();
-        if (txt && txt->Value())
-            out.colorMapXml = txt->Value();
+        auto *n = cm->FirstChild();
+        if (n)
+        {
+            auto *txt = n->ToText();
+            if (txt && txt->Value())
+                out.colorMapXml = txt->Value();
+        }
+    }
+
+    // The mpe element is only present in 1.2+ saves. Flag drives the 1.1 fallback.
+    auto *mpe = e.FirstChildElement("mpe");
+    if (mpe)
+    {
+        out.mpeFromExtraState = true;
+        int active{0};
+        if (mpe->QueryIntAttribute("active", &active) == TIXML_SUCCESS)
+            out.mpeActive = (active != 0);
+        int bendRange{24};
+        if (mpe->QueryIntAttribute("bendRange", &bendRange) == TIXML_SUCCESS)
+            out.mpeBendRange = bendRange;
     }
 }
 
@@ -824,10 +845,44 @@ void Synth::processUIQueue(const clap_output_events_t *outq)
             if (p)
             {
                 dawExtraState = *p;
+                // If the incoming DES had no <mpe> element (1.1-era session), fall back
+                // to the legacy patch slots — patch swap messages are queued before this
+                // one in CLAP stateLoad, so legacy values are already in place. Resolved
+                // state is echoed back so future host saves are written in the new form.
+                if (!dawExtraState.mpeFromExtraState)
+                {
+                    dawExtraState.mpeActive = patch.output.legacyMpeActive.value > 0.5f;
+                    dawExtraState.mpeBendRange =
+                        (int)std::round(patch.output.legacyMpeBendRange.value);
+                }
+                monoValues.mpeActive = dawExtraState.mpeActive;
+                monoValues.mpeBendRange = dawExtraState.mpeBendRange;
+                applyMpeState();
+
                 AudioToUIMsg au{AudioToUIMsg::SET_DAW_EXTRA_STATE};
                 au.dawExtraStatePointer = &dawExtraState;
                 audioToUi.push(au);
             }
+        }
+        break;
+        case MainToAudioMsg::SET_MPE_ACTIVE:
+        {
+            monoValues.mpeActive = uiM->value > 0.5f;
+            dawExtraState.mpeActive = monoValues.mpeActive;
+            applyMpeState();
+            AudioToUIMsg au{AudioToUIMsg::SET_DAW_EXTRA_STATE};
+            au.dawExtraStatePointer = &dawExtraState;
+            audioToUi.push(au);
+        }
+        break;
+        case MainToAudioMsg::SET_MPE_BEND_RANGE:
+        {
+            monoValues.mpeBendRange = std::clamp((int)std::round(uiM->value), 1, 96);
+            dawExtraState.mpeBendRange = monoValues.mpeBendRange;
+            applyMpeState();
+            AudioToUIMsg au{AudioToUIMsg::SET_DAW_EXTRA_STATE};
+            au.dawExtraStatePointer = &dawExtraState;
+            audioToUi.push(au);
         }
         break;
         }
@@ -878,15 +933,7 @@ void Synth::reapplyControlSettings()
     lim = std::clamp(lim, 1, (int)maxVoices);
     voiceManager->setPolyphonyGroupVoiceLimit(0, lim);
 
-    auto mpe = (bool)std::round(patch.output.mpeActive.value);
-    if (mpe)
-    {
-        voiceManager->dialect = voiceManager_t::MIDI1Dialect::MIDI1_MPE;
-    }
-    else
-    {
-        voiceManager->dialect = voiceManager_t::MIDI1Dialect::MIDI1;
-    }
+    applyMpeState();
 
     // End-of-chain high/low cut. The "active" flags gate per-block work.
     // Coefficient setup over-applies on every reapply for now.
@@ -978,6 +1025,12 @@ void Synth::reapplyControlSettings()
         hpFilter.setCutoffAndSampleRate(freq, sr);
         hpFilter.reset();
     }
+}
+
+void Synth::applyMpeState()
+{
+    voiceManager->dialect = monoValues.mpeActive ? voiceManager_t::MIDI1Dialect::MIDI1_MPE
+                                                 : voiceManager_t::MIDI1Dialect::MIDI1;
 }
 
 void Synth::processEndOfBlock(float *L, float *R)
@@ -1085,7 +1138,6 @@ void Synth::handleAudioThreadParamSideEffects(Param *dest)
     if (dest->meta.id == patch.output.playMode.meta.id ||
         dest->meta.id == patch.output.polyLimit.meta.id ||
         dest->meta.id == patch.output.pianoModeActive.meta.id ||
-        dest->meta.id == patch.output.mpeActive.meta.id ||
         dest->meta.id == patch.output.sampleRateStrategy.meta.id ||
         dest->meta.id == patch.output.resampleEngine.meta.id ||
         dest->meta.id == patch.output.lowpass.meta.id ||

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -248,7 +248,7 @@ struct Synth
         {
             auto stb = (b - 8192) * 1.0 / 8192;
             v->voiceValues.mpeBendNormalized = stb;
-            v->voiceValues.mpeBendInSemis = stb * synth.patch.output.mpeBendRange.value;
+            v->voiceValues.mpeBendInSemis = stb * synth.monoValues.mpeBendRange;
         }
         void setVoiceMIDIMPEChannelPressure(Voice *v, int8_t p)
         {
@@ -386,9 +386,17 @@ struct Synth
 
     // Daw-session-only state. Streamed into host state (clap state) but NOT into patches.
     // Holds non-parameter state that is specific to a session and editable only via the editor.
+    //
+    // mpeFromExtraState is a transient marker (not serialized): set true by fromDawExtraState
+    // when the incoming XML actually contained an <mpe> element. The SET_DAW_EXTRA_STATE
+    // handler uses it to decide whether to fall back to the legacy patch slots — only 1.1-era
+    // sessions that stored MPE inside the patch will have it false.
     struct DawExtraState
     {
         std::string colorMapXml;
+        bool mpeActive{false};
+        int mpeBendRange{24};
+        bool mpeFromExtraState{false};
     };
     DawExtraState dawExtraState;
 
@@ -438,7 +446,9 @@ struct Synth
             PANIC_STOP_VOICES,
             SET_DESIGN_MODE_RUN_ALL,
             SET_DAW_EXTRA_STATE,
-            SEND_MACRO_NAME // paramId = macro index, uiManagedPointer = name buffer
+            SET_MPE_ACTIVE,     // value = 0/1; engine-instance, not a patch param
+            SET_MPE_BEND_RANGE, // value = 1..96; engine-instance, not a patch param
+            SEND_MACRO_NAME     // paramId = macro index, uiManagedPointer = name buffer
         } action;
         uint32_t paramId{0};
         float value{0};
@@ -508,6 +518,11 @@ struct Synth
     void reapplyControlSettings();
     void resetSoloState();
     void handleAudioThreadParamSideEffects(Param *dest);
+
+    // Push the current monoValues mpe state into the voice manager (dialect setup).
+    // Called from message handlers when mpeActive / mpeBendRange change, and from the
+    // SET_DAW_EXTRA_STATE handler after dawExtraState is applied.
+    void applyMpeState();
 
     sst::cpputils::active_set_overlay<Param> paramLagSet;
 

--- a/src/synth/voice.cpp
+++ b/src/synth/voice.cpp
@@ -86,8 +86,7 @@ void Voice::renderBlock()
     float retuneKey = voiceValues.key;
     if (monoValues.mtsClient && MTS_HasMaster(monoValues.mtsClient))
     {
-        const auto mpeActive = out.outputNode.mpeActive.value > 0.5f;
-        if (mpeActive)
+        if (monoValues.mpeActive)
         {
             // Interpolate the MTS retuning across the two semitones the
             // bent key straddles, so MPE bend tracks the local scale slope.

--- a/src/ui/playmode-sub-panel.cpp
+++ b/src/ui/playmode-sub-panel.cpp
@@ -19,6 +19,20 @@
 
 namespace baconpaul::six_sines::ui
 {
+// JogUpDownButton variant of DiscreteToValueReference with the 1..96 MPE bend range.
+struct PlayModeSubPanel::MpeBendRangeBinding
+    : sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::JogUpDownButton, int>
+{
+    using Base =
+        sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::JogUpDownButton, int>;
+    using Base::Base;
+    int getMin() const override { return 1; }
+    int getMax() const override { return 96; }
+    int getDefaultValue() const override { return 24; }
+};
+
+PlayModeSubPanel::~PlayModeSubPanel() = default;
+
 PlayModeSubPanel::PlayModeSubPanel(SixSinesEditor &e) : HasEditor(e)
 {
     auto &on = editor.patchCopy.output;
@@ -139,14 +153,46 @@ PlayModeSubPanel::PlayModeSubPanel(SixSinesEditor &e) : HasEditor(e)
     mpeTitle->setText("MPE");
     addAndMakeVisible(*mpeTitle);
 
-    createComponent(editor, *this, on.mpeActive, mpeActiveButton, mpeActiveButtonD);
-    addAndMakeVisible(*mpeActiveButton);
-    mpeActiveButton->setLabel("MPE Active");
-    mpeActiveButtonD->onGuiSetValue = op;
-    editor.componentRefreshByID[on.mpeActive.meta.id] = op;
+    mpeActiveButtonD = std::make_unique<decltype(mpeActiveButtonD)::element_type>(
+        editor.editorDawExtraState.mpeActive);
+    mpeActiveButtonD->setLabel("MPE Active");
+    mpeActiveButtonD->widget->setLabel("MPE Active");
+    mpeActiveButtonD->onValueChanged = [w = juce::Component::SafePointer(this), op](bool v)
+    {
+        if (!w)
+            return;
+        Synth::MainToAudioMsg m{Synth::MainToAudioMsg::SET_MPE_ACTIVE};
+        m.value = v ? 1.f : 0.f;
+        w->editor.mainToAudio.push(m);
+        op();
+    };
+    addAndMakeVisible(*mpeActiveButtonD->widget);
 
-    createComponent(editor, *this, on.mpeBendRange, mpeRange, mpeRangeD);
-    addAndMakeVisible(*mpeRange);
+    mpeRangeD = std::make_unique<MpeBendRangeBinding>(editor.editorDawExtraState.mpeBendRange);
+    mpeRangeD->setLabel("MPE Bend Range");
+    mpeRangeD->onValueChanged = [w = juce::Component::SafePointer(this)](int v)
+    {
+        if (!w)
+            return;
+        Synth::MainToAudioMsg m{Synth::MainToAudioMsg::SET_MPE_BEND_RANGE};
+        m.value = (float)v;
+        w->editor.mainToAudio.push(m);
+    };
+    addAndMakeVisible(*mpeRangeD->widget);
+
+    // Refresh widget visuals + dependent enabled-state when the dawExtraState changes
+    // (e.g. CLAP host stateLoad echoes a SET_DAW_EXTRA_STATE back to the UI).
+    editor.dawExtraStateRefreshListeners.push_back(
+        [w = juce::Component::SafePointer(this)]()
+        {
+            if (!w)
+                return;
+            if (w->mpeActiveButtonD && w->mpeActiveButtonD->widget)
+                w->mpeActiveButtonD->widget->repaint();
+            if (w->mpeRangeD && w->mpeRangeD->widget)
+                w->mpeRangeD->widget->repaint();
+            w->setEnabledState();
+        });
 
     mpeRangeL = std::make_unique<jcmp::Label>();
     mpeRangeL->setText("Bend");
@@ -287,8 +333,8 @@ void PlayModeSubPanel::resized()
 
     auto col4 = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
     col4.add(titleLabelGaplessLayout(mpeTitle));
-    col4.add(jlo::Component(*mpeActiveButton).withHeight(uicLabelHeight));
-    col4.add(jlo::Component(*mpeRange).withHeight(uicLabelHeight));
+    col4.add(jlo::Component(*mpeActiveButtonD->widget).withHeight(uicLabelHeight));
+    col4.add(jlo::Component(*mpeRangeD->widget).withHeight(uicLabelHeight));
     col4.add(jlo::Component(*mpeRangeL).withHeight(uicLabelHeight));
     col4.add(titleLabelGaplessLayout(mtsTitle));
     col4.add(jlo::Component(*mtsStatusLabel).withHeight(uicLabelHeight));
@@ -465,8 +511,8 @@ void PlayModeSubPanel::setEnabledState()
     else
         uniCtL->setText("Voices");
 
-    auto me = editor.patchCopy.output.mpeActive.value > 0.5;
-    mpeRange->setEnabled(me);
+    auto me = editor.editorDawExtraState.mpeActive;
+    mpeRangeD->widget->setEnabled(me);
     mpeRangeL->setEnabled(me);
 
     repaint();

--- a/src/ui/playmode-sub-panel.h
+++ b/src/ui/playmode-sub-panel.h
@@ -17,6 +17,7 @@
 #define BACONPAUL_SIX_SINES_UI_PLAYMODE_SUB_PANEL_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
+#include <sst/jucegui/component-adapters/DiscreteToReference.h>
 #include "six-sines-editor.h"
 #include "dahdsr-components.h"
 #include "lfo-components.h"
@@ -27,7 +28,7 @@ namespace baconpaul::six_sines::ui
 struct PlayModeSubPanel : juce::Component, HasEditor
 {
     PlayModeSubPanel(SixSinesEditor &e);
-    ~PlayModeSubPanel() = default;
+    ~PlayModeSubPanel();
 
     void resized() override;
 
@@ -76,11 +77,15 @@ struct PlayModeSubPanel : juce::Component, HasEditor
     std::unique_ptr<PatchContinuous> uniPanD;
     std::unique_ptr<jcmp::GlyphPainter> uniSpreadG, uniPanG;
 
-    std::unique_ptr<jcmp::ToggleButton> mpeActiveButton;
-    std::unique_ptr<PatchDiscrete> mpeActiveButtonD;
+    // MPE controls bind to engine-instance state (Synth::DawExtraState mirror on the editor),
+    // not to patch params. DiscreteToValueReference owns the widget pointer; the JogUpDown
+    // variant is subclassed in the .cpp to set its 1..96 range.
+    std::unique_ptr<
+        sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::ToggleButton, bool>>
+        mpeActiveButtonD;
 
-    std::unique_ptr<jcmp::JogUpDownButton> mpeRange;
-    std::unique_ptr<PatchDiscrete> mpeRangeD;
+    struct MpeBendRangeBinding;
+    std::unique_ptr<MpeBendRangeBinding> mpeRangeD;
     std::unique_ptr<jcmp::Label> mpeRangeL;
 
     std::unique_ptr<jcmp::JogUpDownButton> tsposeButton;

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -1631,13 +1631,17 @@ void SixSinesEditor::pushDawExtraStateToAudio()
 
 void SixSinesEditor::applyDawExtraStateFromAudio()
 {
-    if (editorDawExtraState.colorMapXml.empty())
-        return;
-    // Apply without writing to the themePath user default: the session's colour map
-    // takes precedence over the user's per-installation preference only within this
-    // session.
-    auto skin = SixSinesSkin::fromXmlString(editorDawExtraState.colorMapXml);
-    applyTheme(skin);
+    if (!editorDawExtraState.colorMapXml.empty())
+    {
+        // Apply without writing to the themePath user default: the session's colour map
+        // takes precedence over the user's per-installation preference only within this
+        // session.
+        auto skin = SixSinesSkin::fromXmlString(editorDawExtraState.colorMapXml);
+        applyTheme(skin);
+    }
+    for (auto &l : dawExtraStateRefreshListeners)
+        if (l)
+            l();
 }
 
 void SixSinesEditor::applyTheme(const SixSinesSkin &skin, const std::string &preference)

--- a/src/ui/six-sines-editor.h
+++ b/src/ui/six-sines-editor.h
@@ -158,8 +158,14 @@ struct SixSinesEditor : jcmp::WindowPanel, sst::jucegui::screens::ScreenHolder<S
     void scheduleDawExtraStatePush();
     void pushDawExtraStateToAudio();
     // Apply a newly-received DES (from the audio thread) to the editor: if it carries a
-    // colour map, parse it and applyTheme().
+    // colour map, parse it and applyTheme(). Also fans out to dawExtraStateRefreshListeners
+    // so widgets bound to non-patch session state (e.g. MPE controls) can refresh.
     void applyDawExtraStateFromAudio();
+
+    // Listeners called whenever editorDawExtraState is replaced by a SET_DAW_EXTRA_STATE
+    // echo from the audio thread. Panels with widgets backed by dawExtraState register here
+    // (e.g. PlayModeSubPanel's MPE active toggle and bend-range jog).
+    std::vector<std::function<void()>> dawExtraStateRefreshListeners;
     // Install the dark base stylesheet + dark skin.  Called once during construction
     // before lnf exists; setThemeFromPreference() then overlays the user's saved theme.
     void initializeBaseSkin();

--- a/tests/perf_scenarios.cpp
+++ b/tests/perf_scenarios.cpp
@@ -132,7 +132,6 @@ void configureScenarioPatch(Patch &patch, const ScenarioSpec &spec)
     patch.output.polyLimit.value = (float)maxVoices;
     patch.output.unisonCount.value = 1.f;
     patch.output.pianoModeActive.value = 0.f;
-    patch.output.mpeActive.value = 0.f;
     patch.output.octTranspose.value = 0.f;
     patch.output.fineTune.value = 0.f;
     patch.output.pan.value = 0.f;


### PR DESCRIPTION
In 1.1 mpeActive and mpeBendRange lived in Patch::OutputNode, so switching presets while playing an MPE controller wiped the player's MPE configuration. MPE state is a property of the MIDI source, not of the patch — move it to MonoValues and persist it via DawExtraState.

The legacy patch slots (ids 33/34) are preserved as legacyMpeActive and legacyMpeBendRange so 1.1 patches still stream cleanly; on first re-save the value flips into the new <mpe> element of DawExtraState.

Bump patchVersion 9 -> 10.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>