### PR TITLE
Smooth per-voice MPE and CLAP note-expression values

### DIFF
--- a/doc/12_roadmap.md
+++ b/doc/12_roadmap.md
@@ -14,21 +14,6 @@ I have a lot of ideas for a '1.2' version of six sines. Not 2.0. Still compatibl
 - LFO -> M etc... depth as an additive and attenuation target
 - Lags, Vias, etc... do we want that (and the 'jacky pressure problem')
 
-## MPE Smoothing
-
-Totally doable but wait until I'm with an MPE device
-
-Plan approved and saved to /Users/paul/.claude/plans/witty-toasting-hoare.md. Project memory updated: 
-new entry project_tests_harness.md records the Catch2 six-sines-test target, the two harness patterns (makePlugin vs direct class), and the rule
-to add new test files to tests/CMakeLists.txt explicitly. Noted your CLAUDE.md edit (line 32 now acknowledges tests).
-
-## Move MPE to per instance
-- Now we have DES move MPE to the instance
-  - if you load a stream which has it from the clap edge set the instance to that
-  - if you load a patch from an sxsnp ignore the patch setting
-  - move the mpe enabled param to be instance based (leave the param in to not break stuff but basically dont use it to drive mpe)
-  - for mpe bend range probably want a user param but that means move the user param manager back to engine
-
 ## Smaller Things from the crew
 - djTubig reports patch swapping kinda slow on windows. Look for profile?
 

--- a/src/dsp/matrix_node.h
+++ b/src/dsp/matrix_node.h
@@ -967,8 +967,8 @@ struct OutputNode : EnvelopeSupport<Patch::OutputNode>,
 
         mech::scale_by<blockSize>(finalEnvLevel, output[0], output[1]);
 
-        auto pn = std::clamp(panMod + pan + panModNode.level + voiceValues.noteExpressionPanBipolar,
-                             -1.f, 1.f);
+        auto pn = std::clamp(
+            panMod + pan + panModNode.level + voiceValues.noteExpressionPanBipolarLag.v, -1.f, 1.f);
         ;
         if (pn != 0.f)
         {

--- a/src/dsp/node_support.h
+++ b/src/dsp/node_support.h
@@ -591,13 +591,13 @@ template <typename Bundle, typename Node> struct ModulationSupport
             break;
 
         case ModMatrixConfig::Source::MPE_PRESSURE:
-            sourcePointers[which] = &voiceValues.mpePressure;
+            sourcePointers[which] = &voiceValues.mpePressureLag.v;
             break;
         case ModMatrixConfig::Source::MPE_TIMBRE:
-            sourcePointers[which] = &voiceValues.mpeTimbre;
+            sourcePointers[which] = &voiceValues.mpeTimbreLag.v;
             break;
         case ModMatrixConfig::Source::MPE_PITCHBEND:
-            sourcePointers[which] = &voiceValues.mpeBendInSemis;
+            sourcePointers[which] = &voiceValues.mpeBendInSemisLag.v;
             break;
 
         case ModMatrixConfig::Source::RANDOM_01:

--- a/src/synth/voice.cpp
+++ b/src/synth/voice.cpp
@@ -55,6 +55,23 @@ void Voice::attack()
     voiceValues.velocityLag.snapTo(voiceValues.velocity);
     voiceValues.velocityLag.setRateInMilliseconds(10, monoValues.sr.sampleRate, 1.0 / blockSize);
 
+    // MPE / note-expression lags: configure rate here but defer the snap to the
+    // first renderBlock — voicemanager dispatches the initial MPE setters AFTER
+    // attack() but before the first audio block, so snapping here would capture
+    // stale values and audibly chirp into the real ones.
+    constexpr float mpeLagMs = 5.f;
+    voiceValues.mpeBendInSemisLag.setRateInMilliseconds(mpeLagMs, monoValues.sr.sampleRate,
+                                                        1.0 / blockSize);
+    voiceValues.mpeTimbreLag.setRateInMilliseconds(mpeLagMs, monoValues.sr.sampleRate,
+                                                   1.0 / blockSize);
+    voiceValues.mpePressureLag.setRateInMilliseconds(mpeLagMs, monoValues.sr.sampleRate,
+                                                     1.0 / blockSize);
+    voiceValues.noteExpressionTuningInSemisLag.setRateInMilliseconds(
+        mpeLagMs, monoValues.sr.sampleRate, 1.0 / blockSize);
+    voiceValues.noteExpressionPanBipolarLag.setRateInMilliseconds(
+        mpeLagMs, monoValues.sr.sampleRate, 1.0 / blockSize);
+    voiceValues.firstBlockAfterAttack = true;
+
     for (auto &n : macroNode)
         n.attack();
     out.attack();
@@ -72,6 +89,26 @@ void Voice::attack()
 
 void Voice::renderBlock()
 {
+    // Advance MPE / note-expression lags before any pitch math or per-node mod
+    // matrix evaluation. On the first block after attack, snap (voicemanager
+    // has already pushed initial setter values into voiceValues at this point);
+    // afterwards smooth.
+    auto stepLag = [g = voiceValues.firstBlockAfterAttack](auto &lag, float target)
+    {
+        if (g)
+            lag.snapTo(target);
+        else
+        {
+            lag.setTarget(target);
+            lag.process();
+        }
+    };
+    stepLag(voiceValues.mpeBendInSemisLag, voiceValues.mpeBendInSemis);
+    stepLag(voiceValues.mpeTimbreLag, voiceValues.mpeTimbre);
+    stepLag(voiceValues.mpePressureLag, voiceValues.mpePressure);
+    stepLag(voiceValues.noteExpressionTuningInSemisLag, voiceValues.noteExpressionTuningInSemis);
+    stepLag(voiceValues.noteExpressionPanBipolarLag, voiceValues.noteExpressionPanBipolar);
+
     // Refresh unison-derived per-voice scalars from the (smoothed) mono hoists so
     // unisonSpread / unisonPan track host automation and UI knob moves mid-note.
     if (voiceValues.uniCount > 1)
@@ -90,7 +127,8 @@ void Voice::renderBlock()
         {
             // Interpolate the MTS retuning across the two semitones the
             // bent key straddles, so MPE bend tracks the local scale slope.
-            float floatKey = (float)voiceValues.key + voiceValues.mpeBendInSemis;
+            const float bend = voiceValues.mpeBendInSemisLag.v;
+            float floatKey = (float)voiceValues.key + bend;
             int iFloatKey = (int)std::floor(floatKey);
             int loKey = std::clamp(iFloatKey, 0, 126);
             int hiKey = loKey + 1;
@@ -99,7 +137,7 @@ void Voice::renderBlock()
                 MTS_RetuningInSemitones(monoValues.mtsClient, loKey, voiceValues.channel);
             float hiRetune =
                 MTS_RetuningInSemitones(monoValues.mtsClient, hiKey, voiceValues.channel);
-            retuneKey += voiceValues.mpeBendInSemis + (1.f - frac) * loRetune + frac * hiRetune;
+            retuneKey += bend + (1.f - frac) * loRetune + frac * hiRetune;
         }
         else
         {
@@ -109,11 +147,11 @@ void Voice::renderBlock()
     }
     else
     {
-        retuneKey += voiceValues.mpeBendInSemis;
+        retuneKey += voiceValues.mpeBendInSemisLag.v;
     }
     retuneKey += ((monoValues.pitchBend >= 0) ? out.bendUp : out.bendDown) * monoValues.pitchBend;
     retuneKey += voiceValues.portaDiff * voiceValues.portaSign;
-    retuneKey += voiceValues.noteExpressionTuningInSemis;
+    retuneKey += voiceValues.noteExpressionTuningInSemisLag.v;
     retuneKey += out.fineTune * 0.01 + out.ftModNode.coarseTune + out.ftModNode.level * 2 +
                  out.ftModNode.coarseLevel;
 
@@ -193,6 +231,8 @@ void Voice::renderBlock()
         }
         fadeBlocks--;
     }
+
+    voiceValues.firstBlockAfterAttack = false;
 }
 
 static_assert(numOps == 6, "Rebuild this table if not");
@@ -312,6 +352,11 @@ void Voice::cleanup()
     voiceValues.dPorta = 0;
     voiceValues.dPortaFrac = 0;
     voiceValues.mpeBendInSemis = 0;
+    voiceValues.mpeBendNormalized = 0;
+    voiceValues.mpeTimbre = 0;
+    voiceValues.mpePressure = 0;
+    voiceValues.noteExpressionTuningInSemis = 0;
+    voiceValues.noteExpressionPanBipolar = 0;
 
     for (auto &m : macroNode)
         m.envCleanup();

--- a/src/synth/voice_values.h
+++ b/src/synth/voice_values.h
@@ -67,6 +67,17 @@ struct VoiceValues
 
     sst::basic_blocks::dsp::OnePoleLag<float, false> velocityLag;
 
+    // Per-voice smoothing for MPE / note-expression values. Mod-matrix sources
+    // for MPE_* point at the corresponding lag's .v (see node_support.h).
+    sst::basic_blocks::dsp::OnePoleLag<float, false> mpeBendInSemisLag;
+    sst::basic_blocks::dsp::OnePoleLag<float, false> mpeTimbreLag;
+    sst::basic_blocks::dsp::OnePoleLag<float, false> mpePressureLag;
+    sst::basic_blocks::dsp::OnePoleLag<float, false> noteExpressionTuningInSemisLag;
+    sst::basic_blocks::dsp::OnePoleLag<float, false> noteExpressionPanBipolarLag;
+
+    // True for one renderBlock after attack(); see Voice::renderBlock for snap logic.
+    bool firstBlockAfterAttack{true};
+
     std::array<float, numMacros> macroOut{};
 
   private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(six-sines-test
 		structure.cpp
 		factory_patches.cpp
 		output_stage_dsp.cpp
+		mpe_smoothing.cpp
 )
 
 target_link_libraries(six-sines-test

--- a/tests/mpe_smoothing.cpp
+++ b/tests/mpe_smoothing.cpp
@@ -1,0 +1,192 @@
+/*
+ * Per-voice smoothing of MPE / note-expression values.
+ *
+ * Voice::renderBlock advances five OnePoleLags at the top of the block: three
+ * MPE (pressure / timbre / bend-in-semis) and two note-expression
+ * (tuningInSemis / panBipolar). On the first block after attack() they snap;
+ * thereafter they smooth at ~5 ms. Mod-matrix MPE sources are repointed at
+ * the lag's .v in rebindPointer.
+ */
+
+#include "catch2/catch2.hpp"
+#include "configuration.h"
+#include "synth/patch.h"
+#include "synth/synth.h"
+#include "synth/voice.h"
+#include "synth/mod_matrix.h"
+
+#include <memory>
+
+using namespace baconpaul::six_sines;
+
+namespace
+{
+// Minimal patch config: one operator audible so a voice has somewhere to go,
+// envelopes long enough that the voice doesn't auto-release during the test.
+void configureMinimalPatch(Patch &patch)
+{
+    patch.output.level.value = 0.5f;
+    patch.output.playMode.value = 0.f; // poly
+    patch.output.polyLimit.value = (float)maxVoices;
+    patch.output.unisonCount.value = 1.f;
+
+    auto setSustainedEnv = [](Patch::DAHDSRMixin &e)
+    {
+        e.delay.value = 0.f;
+        e.attack.value = 0.f;
+        e.hold.value = 0.f;
+        e.decay.value = 0.f;
+        e.sustain.value = 1.f;
+        e.release.value = 0.5f;
+        e.envPower.value = 1.f;
+        e.envIsMultiplcative.value = 1.f;
+        e.envIsOneShot.value = 0.f;
+    };
+    setSustainedEnv(patch.output);
+
+    for (int i = 0; i < (int)numOps; ++i)
+    {
+        patch.sourceNodes[i].active.value = (i == 0) ? 1.f : 0.f;
+        patch.sourceNodes[i].ratio.value = 0.f;
+        patch.sourceNodes[i].keyTrack.value = 1.f;
+        setSustainedEnv(patch.sourceNodes[i]);
+
+        patch.mixerNodes[i].active.value = (i == 0) ? 1.f : 0.f;
+        patch.mixerNodes[i].level.value = 0.5f;
+        setSustainedEnv(patch.mixerNodes[i]);
+    }
+}
+
+// Bring up a Synth + minimal patch ready to receive noteOns. No noteOn fired.
+std::unique_ptr<Synth> bringUpSynth(double hostSampleRate = 48000.0)
+{
+    auto s = std::make_unique<Synth>(false);
+    s->setSampleRate(hostSampleRate);
+    configureMinimalPatch(s->patch);
+    s->reapplyControlSettings();
+    return s;
+}
+} // namespace
+
+// Test 1: on the first block after attack(), each lag must snap exactly to
+// whatever value sits in the raw field at the moment renderBlock runs. This
+// is the chirp regression — voicemanager dispatches the initial MPE setters
+// AFTER attack() but BEFORE the first audio block, and a snap-in-attack
+// design would have captured stale values.
+TEST_CASE("mpe_lag attack snap", "[mpe_smoothing]")
+{
+    auto synth = bringUpSynth();
+    synth->voiceManager->processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f);
+    auto *v = synth->head;
+    REQUIRE(v != nullptr);
+
+    // Simulate setVoiceMIDIMPE* / setNoteExpression dispatching after attack.
+    v->voiceValues.mpePressure = 0.8f;
+    v->voiceValues.mpeTimbre = 0.3f;
+    v->voiceValues.mpeBendInSemis = 7.0f;
+    v->voiceValues.noteExpressionTuningInSemis = -2.0f;
+    v->voiceValues.noteExpressionPanBipolar = 0.5f;
+
+    REQUIRE(v->voiceValues.firstBlockAfterAttack);
+    synth->process(nullptr);
+    REQUIRE_FALSE(v->voiceValues.firstBlockAfterAttack);
+
+    REQUIRE(v->voiceValues.mpePressureLag.v == Approx(0.8f).margin(1e-7));
+    REQUIRE(v->voiceValues.mpeTimbreLag.v == Approx(0.3f).margin(1e-7));
+    REQUIRE(v->voiceValues.mpeBendInSemisLag.v == Approx(7.0f).margin(1e-6));
+    REQUIRE(v->voiceValues.noteExpressionTuningInSemisLag.v == Approx(-2.0f).margin(1e-6));
+    REQUIRE(v->voiceValues.noteExpressionPanBipolarLag.v == Approx(0.5f).margin(1e-7));
+}
+
+// Test 2: after the first block, target changes must smooth rather than snap.
+// One block in mid-flight is strictly between old and new; ~50 blocks past
+// the lag's time constant lands at the target within a tight margin.
+TEST_CASE("mpe_lag mid-note smoothing", "[mpe_smoothing]")
+{
+    auto synth = bringUpSynth();
+    synth->voiceManager->processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f);
+    auto *v = synth->head;
+    REQUIRE(v != nullptr);
+
+    // First block: snap to 0.
+    v->voiceValues.mpePressure = 0.f;
+    synth->process(nullptr);
+    REQUIRE(v->voiceValues.mpePressureLag.v == 0.f);
+
+    // Step to 1.0 and process one host block. Lag must be in-flight, not snapped.
+    v->voiceValues.mpePressure = 1.f;
+    synth->process(nullptr);
+    REQUIRE(v->voiceValues.mpePressureLag.v > 0.f);
+    REQUIRE(v->voiceValues.mpePressureLag.v < 1.f);
+
+    // After many blocks the lag converges to the target.
+    for (int i = 0; i < 200; ++i)
+        synth->process(nullptr);
+    REQUIRE(v->voiceValues.mpePressureLag.v == Approx(1.f).margin(1e-3));
+}
+
+// Test 3: every attack() resets firstBlockAfterAttack, so a fresh voice
+// always snaps to its own initial MPE state — no leak from another voice
+// already in flight on the same engine.
+TEST_CASE("mpe_lag fresh attack always snaps", "[mpe_smoothing]")
+{
+    auto synth = bringUpSynth();
+
+    // Voice A: trigger, set bend, run enough host blocks that A's lag is
+    // safely past the snap (firstBlockAfterAttack cleared) and smoothing
+    // toward a different target.
+    synth->voiceManager->processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f);
+    auto *vA = synth->head;
+    REQUIRE(vA != nullptr);
+    vA->voiceValues.mpeBendInSemis = 12.0f;
+    synth->process(nullptr);
+    REQUIRE(vA->voiceValues.mpeBendInSemisLag.v == Approx(12.0f).margin(1e-6));
+    vA->voiceValues.mpeBendInSemis = 0.0f;
+    for (int i = 0; i < 5; ++i)
+        synth->process(nullptr);
+    REQUIRE_FALSE(vA->voiceValues.firstBlockAfterAttack);
+
+    // Voice B: trigger on a different key. Its own firstBlockAfterAttack
+    // must be true (independent of A's), and its first block must snap to
+    // its own target, not chirp from 0.
+    synth->voiceManager->processNoteOnEvent(0, 0, 62, -1, 0.8f, 0.f);
+    Voice *vB = nullptr;
+    for (auto *c = synth->head; c != nullptr; c = c->next)
+        if (c != vA)
+            vB = c;
+    REQUIRE(vB != nullptr);
+    REQUIRE(vB->voiceValues.firstBlockAfterAttack);
+    vB->voiceValues.mpeBendInSemis = -7.0f;
+    synth->process(nullptr);
+    REQUIRE(vB->voiceValues.mpeBendInSemisLag.v == Approx(-7.0f).margin(1e-6));
+}
+
+// Test 4: rebindPointer must point MPE_* mod sources at the lag's .v, not at
+// the raw field. Otherwise smoothing wouldn't reach the mod matrix.
+TEST_CASE("mpe_lag mod source pointer rebind", "[mpe_smoothing]")
+{
+    auto synth = bringUpSynth();
+
+    // Wire OutputNode's three mod slots to the three MPE sources before
+    // triggering noteOn so attack()/bindModulation() pick them up.
+    synth->patch.output.modsource[0].value = (float)ModMatrixConfig::Source::MPE_PRESSURE;
+    synth->patch.output.modsource[1].value = (float)ModMatrixConfig::Source::MPE_TIMBRE;
+    synth->patch.output.modsource[2].value = (float)ModMatrixConfig::Source::MPE_PITCHBEND;
+    synth->reapplyControlSettings();
+
+    synth->voiceManager->processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f);
+    auto *v = synth->head;
+    REQUIRE(v != nullptr);
+
+    // Points-at-lag .v.
+    REQUIRE(v->out.sourcePointers[0] ==
+            static_cast<const float *>(&v->voiceValues.mpePressureLag.v));
+    REQUIRE(v->out.sourcePointers[1] == static_cast<const float *>(&v->voiceValues.mpeTimbreLag.v));
+    REQUIRE(v->out.sourcePointers[2] ==
+            static_cast<const float *>(&v->voiceValues.mpeBendInSemisLag.v));
+
+    // Does NOT point at the raw field.
+    REQUIRE(v->out.sourcePointers[0] != static_cast<const float *>(&v->voiceValues.mpePressure));
+    REQUIRE(v->out.sourcePointers[1] != static_cast<const float *>(&v->voiceValues.mpeTimbre));
+    REQUIRE(v->out.sourcePointers[2] != static_cast<const float *>(&v->voiceValues.mpeBendInSemis));
+}


### PR DESCRIPTION
Apply a 5ms one-pole lag to mpeBendInSemis, mpeTimbre, mpePressure, noteExpressionTuningInSemis, and noteExpressionPanBipolar so fast expression sweeps no longer zipper through pitch, pan, and any mod-matrix destination driven by an MPE source. The lag rate is configured in attack() but snapped on the first renderBlock — the voicemanager dispatches the initial MPE setters after attack() but before the first audio block, so snapping in attack would have captured stale slot values and audibly chirped into the real ones. The MPE_PRESSURE / MPE_TIMBRE / MPE_PITCHBEND mod sources are re-pointed at the lag's .v in rebindPointer, and Voice::cleanup zeros all five raw fields for safe slot reuse.

Adds tests/mpe_smoothing.cpp covering first-block snap, mid-note smoothing, fresh-attack snap, and mod-source pointer rebind.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>