### PR TITLE
Engine-wide MIDI and param-automation smoothing times

### DIFF
--- a/src/synth/mono_values.h
+++ b/src/synth/mono_values.h
@@ -93,6 +93,13 @@ struct MonoValues
     // via Synth::DawExtraState so DAW sessions round-trip without polluting patches.
     bool mpeActive{false};
     int mpeBendRange{24};
+
+    // Engine-wide smoothing times, in milliseconds. Mirrored from Synth::DawExtraState.
+    // midiCCSmoothingTimeMs governs MIDI CC, MPE (bend/pressure/timbre), and per-voice
+    // note-expression lags. paramAutomationSmoothingTimeMs governs the per-param lag
+    // applied to host parameter automation.
+    float midiCCSmoothingTimeMs{25.f};
+    float paramAutomationSmoothingTimeMs{2.f};
 };
 }; // namespace baconpaul::six_sines
 #endif // MONO_VALUES_H

--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -106,6 +106,12 @@ void Synth::toDawExtraState(TiXmlElement &e) const
     mpe.SetAttribute("active", monoValues.mpeActive ? 1 : 0);
     mpe.SetAttribute("bendRange", monoValues.mpeBendRange);
     e.InsertEndChild(mpe);
+
+    // Engine-wide smoothing times (ms). Absent in pre-1.x saves; defaults in DawExtraState apply.
+    TiXmlElement sm("smoothing");
+    sm.SetDoubleAttribute("midiCCMs", dawExtraState.midiCCSmoothingTimeMs);
+    sm.SetDoubleAttribute("paramAutomationMs", dawExtraState.paramAutomationSmoothingTimeMs);
+    e.InsertEndChild(sm);
 }
 
 void Synth::fromDawExtraState(TiXmlElement &e, DawExtraState &out)
@@ -134,6 +140,17 @@ void Synth::fromDawExtraState(TiXmlElement &e, DawExtraState &out)
         int bendRange{24};
         if (mpe->QueryIntAttribute("bendRange", &bendRange) == TIXML_SUCCESS)
             out.mpeBendRange = bendRange;
+    }
+
+    // Smoothing element absent in older saves; struct defaults stand.
+    auto *sm = e.FirstChildElement("smoothing");
+    if (sm)
+    {
+        double v{0.0};
+        if (sm->QueryDoubleAttribute("midiCCMs", &v) == TIXML_SUCCESS)
+            out.midiCCSmoothingTimeMs = (float)v;
+        if (sm->QueryDoubleAttribute("paramAutomationMs", &v) == TIXML_SUCCESS)
+            out.paramAutomationSmoothingTimeMs = (float)v;
     }
 }
 
@@ -239,13 +256,16 @@ void Synth::setSampleRate(double sampleRate)
 
     for (auto &[i, p] : patch.paramMap)
     {
-        p->lag.setRateInMilliseconds(1000.0 * 64.0 / 48000.0, engineSampleRate, 1.0 / blockSize);
+        // paramAutomationSmoothingTimeMs is in milliseconds.
+        p->lag.setRateInMilliseconds(monoValues.paramAutomationSmoothingTimeMs, engineSampleRate,
+                                     1.0 / blockSize);
         p->lag.snapTo(p->value);
     }
     paramLagSet.removeAll();
 
-    // midi is a bit less frequent than param automation so a slightly slower smooth
-    midiCCLagCollection.setRateInMilliseconds(1000.0 * 128.0 / 48000.0, engineSampleRate,
+    // midiCCSmoothingTimeMs is in milliseconds; also applies to MPE / note-expression lags
+    // configured per-voice on attack.
+    midiCCLagCollection.setRateInMilliseconds(monoValues.midiCCSmoothingTimeMs, engineSampleRate,
                                               1.0 / blockSize);
     midiCCLagCollection.snapAllActiveToTarget();
 
@@ -857,7 +877,11 @@ void Synth::processUIQueue(const clap_output_events_t *outq)
                 }
                 monoValues.mpeActive = dawExtraState.mpeActive;
                 monoValues.mpeBendRange = dawExtraState.mpeBendRange;
+                monoValues.midiCCSmoothingTimeMs = dawExtraState.midiCCSmoothingTimeMs;
+                monoValues.paramAutomationSmoothingTimeMs =
+                    dawExtraState.paramAutomationSmoothingTimeMs;
                 applyMpeState();
+                applySmoothingTimes();
 
                 AudioToUIMsg au{AudioToUIMsg::SET_DAW_EXTRA_STATE};
                 au.dawExtraStatePointer = &dawExtraState;
@@ -880,6 +904,27 @@ void Synth::processUIQueue(const clap_output_events_t *outq)
             monoValues.mpeBendRange = std::clamp((int)std::round(uiM->value), 1, 96);
             dawExtraState.mpeBendRange = monoValues.mpeBendRange;
             applyMpeState();
+            AudioToUIMsg au{AudioToUIMsg::SET_DAW_EXTRA_STATE};
+            au.dawExtraStatePointer = &dawExtraState;
+            audioToUi.push(au);
+        }
+        break;
+        case MainToAudioMsg::SET_MIDI_CC_SMOOTHING_TIME_MS:
+        {
+            monoValues.midiCCSmoothingTimeMs = std::max(0.f, uiM->value);
+            dawExtraState.midiCCSmoothingTimeMs = monoValues.midiCCSmoothingTimeMs;
+            applySmoothingTimes();
+            AudioToUIMsg au{AudioToUIMsg::SET_DAW_EXTRA_STATE};
+            au.dawExtraStatePointer = &dawExtraState;
+            audioToUi.push(au);
+        }
+        break;
+        case MainToAudioMsg::SET_PARAM_AUTOMATION_SMOOTHING_TIME_MS:
+        {
+            monoValues.paramAutomationSmoothingTimeMs = std::max(0.f, uiM->value);
+            dawExtraState.paramAutomationSmoothingTimeMs =
+                monoValues.paramAutomationSmoothingTimeMs;
+            applySmoothingTimes();
             AudioToUIMsg au{AudioToUIMsg::SET_DAW_EXTRA_STATE};
             au.dawExtraStatePointer = &dawExtraState;
             audioToUi.push(au);
@@ -1031,6 +1076,19 @@ void Synth::applyMpeState()
 {
     voiceManager->dialect = monoValues.mpeActive ? voiceManager_t::MIDI1Dialect::MIDI1_MPE
                                                  : voiceManager_t::MIDI1Dialect::MIDI1;
+}
+
+void Synth::applySmoothingTimes()
+{
+    if (engineSampleRate <= 0)
+        return;
+    midiCCLagCollection.setRateInMilliseconds(monoValues.midiCCSmoothingTimeMs, engineSampleRate,
+                                              1.0 / blockSize);
+    for (auto &[i, p] : patch.paramMap)
+    {
+        p->lag.setRateInMilliseconds(monoValues.paramAutomationSmoothingTimeMs, engineSampleRate,
+                                     1.0 / blockSize);
+    }
 }
 
 void Synth::processEndOfBlock(float *L, float *R)

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -397,6 +397,12 @@ struct Synth
         bool mpeActive{false};
         int mpeBendRange{24};
         bool mpeFromExtraState{false};
+
+        // Engine-wide smoothing times, in milliseconds.
+        // midiCCSmoothingTimeMs: MIDI CC + MPE + note-expression lags.
+        // paramAutomationSmoothingTimeMs: per-param host-automation lag.
+        float midiCCSmoothingTimeMs{25.f};
+        float paramAutomationSmoothingTimeMs{2.f};
     };
     DawExtraState dawExtraState;
 
@@ -446,9 +452,11 @@ struct Synth
             PANIC_STOP_VOICES,
             SET_DESIGN_MODE_RUN_ALL,
             SET_DAW_EXTRA_STATE,
-            SET_MPE_ACTIVE,     // value = 0/1; engine-instance, not a patch param
-            SET_MPE_BEND_RANGE, // value = 1..96; engine-instance, not a patch param
-            SEND_MACRO_NAME     // paramId = macro index, uiManagedPointer = name buffer
+            SET_MPE_ACTIVE,                // value = 0/1; engine-instance, not a patch param
+            SET_MPE_BEND_RANGE,            // value = 1..96; engine-instance, not a patch param
+            SET_MIDI_CC_SMOOTHING_TIME_MS, // value = ms; engine-instance
+            SET_PARAM_AUTOMATION_SMOOTHING_TIME_MS, // value = ms; engine-instance
+            SEND_MACRO_NAME // paramId = macro index, uiManagedPointer = name buffer
         } action;
         uint32_t paramId{0};
         float value{0};
@@ -523,6 +531,10 @@ struct Synth
     // Called from message handlers when mpeActive / mpeBendRange change, and from the
     // SET_DAW_EXTRA_STATE handler after dawExtraState is applied.
     void applyMpeState();
+
+    // Re-rates the engine-wide MIDI CC lag and per-param-map lags from monoValues smoothing
+    // times. Active voices keep their attack-time MPE/NE rates — those refresh on next attack.
+    void applySmoothingTimes();
 
     sst::cpputils::active_set_overlay<Param> paramLagSet;
 

--- a/src/synth/voice.cpp
+++ b/src/synth/voice.cpp
@@ -59,7 +59,8 @@ void Voice::attack()
     // first renderBlock — voicemanager dispatches the initial MPE setters AFTER
     // attack() but before the first audio block, so snapping here would capture
     // stale values and audibly chirp into the real ones.
-    constexpr float mpeLagMs = 5.f;
+    // Engine-wide smoothing time, in milliseconds, shared with the MIDI CC lag.
+    const float mpeLagMs = monoValues.midiCCSmoothingTimeMs;
     voiceValues.mpeBendInSemisLag.setRateInMilliseconds(mpeLagMs, monoValues.sr.sampleRate,
                                                         1.0 / blockSize);
     voiceValues.mpeTimbreLag.setRateInMilliseconds(mpeLagMs, monoValues.sr.sampleRate,

--- a/src/ui/playmode-sub-panel.cpp
+++ b/src/ui/playmode-sub-panel.cpp
@@ -14,23 +14,13 @@
  */
 
 #include "playmode-sub-panel.h"
+#include <array>
+#include <sstream>
 #include <sst/jucegui/layouts/ListLayout.h>
 #include "libMTSClient.h"
 
 namespace baconpaul::six_sines::ui
 {
-// JogUpDownButton variant of DiscreteToValueReference with the 1..96 MPE bend range.
-struct PlayModeSubPanel::MpeBendRangeBinding
-    : sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::JogUpDownButton, int>
-{
-    using Base =
-        sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::JogUpDownButton, int>;
-    using Base::Base;
-    int getMin() const override { return 1; }
-    int getMax() const override { return 96; }
-    int getDefaultValue() const override { return 24; }
-};
-
 PlayModeSubPanel::~PlayModeSubPanel() = default;
 
 PlayModeSubPanel::PlayModeSubPanel(SixSinesEditor &e) : HasEditor(e)
@@ -149,14 +139,19 @@ PlayModeSubPanel::PlayModeSubPanel(SixSinesEditor &e) : HasEditor(e)
     addAndMakeVisible(*uniTitle);
     editor.componentRefreshByID[on.unisonCount.meta.id] = op;
 
-    mpeTitle = std::make_unique<jcmp::RuledLabel>();
-    mpeTitle->setText("MPE");
-    addAndMakeVisible(*mpeTitle);
+    smoothingSectionTitle = std::make_unique<jcmp::RuledLabel>();
+    smoothingSectionTitle->setText("MPE + Smoothing");
+    addAndMakeVisible(*smoothingSectionTitle);
+
+    mpeRowLabel = std::make_unique<jcmp::Label>();
+    mpeRowLabel->setText("MPE");
+    mpeRowLabel->setJustification(juce::Justification::centredRight);
+    addAndMakeVisible(*mpeRowLabel);
 
     mpeActiveButtonD = std::make_unique<decltype(mpeActiveButtonD)::element_type>(
         editor.editorDawExtraState.mpeActive);
     mpeActiveButtonD->setLabel("MPE Active");
-    mpeActiveButtonD->widget->setLabel("MPE Active");
+    mpeActiveButtonD->widget->setLabel("Active");
     mpeActiveButtonD->onValueChanged = [w = juce::Component::SafePointer(this), op](bool v)
     {
         if (!w)
@@ -168,17 +163,25 @@ PlayModeSubPanel::PlayModeSubPanel(SixSinesEditor &e) : HasEditor(e)
     };
     addAndMakeVisible(*mpeActiveButtonD->widget);
 
-    mpeRangeD = std::make_unique<MpeBendRangeBinding>(editor.editorDawExtraState.mpeBendRange);
-    mpeRangeD->setLabel("MPE Bend Range");
-    mpeRangeD->onValueChanged = [w = juce::Component::SafePointer(this)](int v)
+    mpeRangeEditor = std::make_unique<jcmp::TextEditor>();
+    mpeRangeEditor->setMultiLine(false);
+    mpeRangeEditor->setReturnKeyStartsNewLine(false);
+    mpeRangeEditor->setJustification(juce::Justification::centred);
+    mpeRangeEditor->setIndents(3, 1);
+    mpeRangeEditor->setInputRestrictions(3, "0123456789");
+    mpeRangeEditor->setTitle("MPE Bend Range");
+    mpeRangeEditor->onReturnKey = [w = juce::Component::SafePointer(this)]()
     {
-        if (!w)
-            return;
-        Synth::MainToAudioMsg m{Synth::MainToAudioMsg::SET_MPE_BEND_RANGE};
-        m.value = (float)v;
-        w->editor.mainToAudio.push(m);
+        if (w)
+            w->commitMpeRangeEditor();
     };
-    addAndMakeVisible(*mpeRangeD->widget);
+    mpeRangeEditor->onFocusLost = [w = juce::Component::SafePointer(this)]()
+    {
+        if (w)
+            w->commitMpeRangeEditor();
+    };
+    refreshMpeRangeEditor();
+    addAndMakeVisible(*mpeRangeEditor);
 
     // Refresh widget visuals + dependent enabled-state when the dawExtraState changes
     // (e.g. CLAP host stateLoad echoes a SET_DAW_EXTRA_STATE back to the UI).
@@ -189,14 +192,46 @@ PlayModeSubPanel::PlayModeSubPanel(SixSinesEditor &e) : HasEditor(e)
                 return;
             if (w->mpeActiveButtonD && w->mpeActiveButtonD->widget)
                 w->mpeActiveButtonD->widget->repaint();
-            if (w->mpeRangeD && w->mpeRangeD->widget)
-                w->mpeRangeD->widget->repaint();
+            w->refreshMpeRangeEditor();
+            w->refreshMidiSmoothingButton();
+            w->refreshParamSmoothingButton();
             w->setEnabledState();
         });
 
     mpeRangeL = std::make_unique<jcmp::Label>();
     mpeRangeL->setText("Bend");
+    mpeRangeL->setJustification(juce::Justification::centredRight);
     addAndMakeVisible(*mpeRangeL);
+
+    smoothingRowLabel = std::make_unique<jcmp::Label>();
+    smoothingRowLabel->setText("MIDI Smoothing");
+    smoothingRowLabel->setJustification(juce::Justification::centredRight);
+    addAndMakeVisible(*smoothingRowLabel);
+
+    midiSmoothingButton = std::make_unique<jcmp::MenuButton>();
+    midiSmoothingButton->setOnCallback(
+        [w = juce::Component::SafePointer(this)]()
+        {
+            if (w)
+                w->showMidiSmoothingMenu();
+        });
+    refreshMidiSmoothingButton();
+    addAndMakeVisible(*midiSmoothingButton);
+
+    paramSmoothingRowLabel = std::make_unique<jcmp::Label>();
+    paramSmoothingRowLabel->setText("Param Smoothing");
+    paramSmoothingRowLabel->setJustification(juce::Justification::centredRight);
+    addAndMakeVisible(*paramSmoothingRowLabel);
+
+    paramSmoothingButton = std::make_unique<jcmp::MenuButton>();
+    paramSmoothingButton->setOnCallback(
+        [w = juce::Component::SafePointer(this)]()
+        {
+            if (w)
+                w->showParamSmoothingMenu();
+        });
+    refreshParamSmoothingButton();
+    addAndMakeVisible(*paramSmoothingButton);
 
     tsposeTitle = std::make_unique<jcmp::RuledLabel>();
     tsposeTitle->setText("Octave");
@@ -294,7 +329,7 @@ void PlayModeSubPanel::resized()
     //   col1: Voices / Unison
     //   col2: Play (mode + triggers + porta)
     //   col3: Bend / Octave
-    //   col4: MPE / Panic
+    //   col4: MTS / Panic
     // The two tallest columns (1 and 2) drive the row height.
     auto topRowHeight = uicTitleLabelInnerBox + 7 * uicLabelHeight + 7 * uicMargin;
 
@@ -332,10 +367,6 @@ void PlayModeSubPanel::resized()
     topRow.add(col3);
 
     auto col4 = jlo::VList().withWidth(skinny).withAutoGap(uicMargin);
-    col4.add(titleLabelGaplessLayout(mpeTitle));
-    col4.add(jlo::Component(*mpeActiveButtonD->widget).withHeight(uicLabelHeight));
-    col4.add(jlo::Component(*mpeRangeD->widget).withHeight(uicLabelHeight));
-    col4.add(jlo::Component(*mpeRangeL).withHeight(uicLabelHeight));
     col4.add(titleLabelGaplessLayout(mtsTitle));
     col4.add(jlo::Component(*mtsStatusLabel).withHeight(uicLabelHeight));
     col4.add(titleLabelGaplessLayout(panicTitle));
@@ -345,14 +376,40 @@ void PlayModeSubPanel::resized()
     outer.add(topRow);
 
     auto fullWidth = getWidth() - 2 * uicMargin;
+
+    // "MPE + Smoothing" section: full-width title with three rows underneath.
+    outer.add(titleLabelGaplessLayout(smoothingSectionTitle).withWidth(fullWidth));
+
+    auto smoothingColHeight = 3 * uicLabelHeight + 2 * uicMargin;
+    auto smoothingCol =
+        jlo::VList().withWidth(fullWidth).withHeight(smoothingColHeight).withAutoGap(uicMargin);
+    int labelW = fullWidth / 3;
+
+    auto mpeRow = jlo::HList().withHeight(uicLabelHeight).withAutoGap(uicMargin);
+    mpeRow.add(jlo::Component(*mpeRowLabel).withWidth(labelW));
+    mpeRow.add(jlo::Component(*mpeActiveButtonD->widget).withWidth(uicSubPanelColumnWidth * 1.5));
+    mpeRow.add(jlo::Component(*mpeRangeL).withWidth(uicLabelHeight * 2));
+    mpeRow.add(jlo::Component(*mpeRangeEditor).expandToFill());
+    smoothingCol.add(mpeRow);
+
+    auto smRow = jlo::HList().withHeight(uicLabelHeight).withAutoGap(uicMargin);
+    smRow.add(jlo::Component(*smoothingRowLabel).withWidth(labelW));
+    smRow.add(jlo::Component(*midiSmoothingButton).expandToFill());
+    smoothingCol.add(smRow);
+
+    auto psRow = jlo::HList().withHeight(uicLabelHeight).withAutoGap(uicMargin);
+    psRow.add(jlo::Component(*paramSmoothingRowLabel).withWidth(labelW));
+    psRow.add(jlo::Component(*paramSmoothingButton).expandToFill());
+    smoothingCol.add(psRow);
+
+    outer.add(smoothingCol);
+
     outer.add(titleLabelGaplessLayout(outputControlTitle).withWidth(fullWidth));
 
     // Output signal path. Each row is "Label : [control(s)]". Saturation row also
     // gets a drive HSlider following the type jog. Future revision will add
     // arrow connectors between stages.
     auto pathCol = jlo::VList().withWidth(fullWidth).withAutoGap(uicMargin);
-
-    int labelW = fullWidth / 3;
 
     auto stageRow = [&](auto &lbl, auto &c1, juce::Component *c2 = nullptr)
     {
@@ -512,7 +569,7 @@ void PlayModeSubPanel::setEnabledState()
         uniCtL->setText("Voices");
 
     auto me = editor.editorDawExtraState.mpeActive;
-    mpeRangeD->widget->setEnabled(me);
+    mpeRangeEditor->setEnabled(me);
     mpeRangeL->setEnabled(me);
 
     repaint();
@@ -577,6 +634,104 @@ void PlayModeSubPanel::updateMTSStatus()
         mtsStatusLabel->setEnabled(connected);
         mtsStatusLabel->setText(text);
     }
+}
+
+void PlayModeSubPanel::refreshMpeRangeEditor()
+{
+    auto v = editor.editorDawExtraState.mpeBendRange;
+    mpeRangeEditor->setAllText(std::to_string(v));
+}
+
+void PlayModeSubPanel::commitMpeRangeEditor()
+{
+    auto txt = mpeRangeEditor->getText().trim();
+    int v = txt.isEmpty() ? editor.editorDawExtraState.mpeBendRange : txt.getIntValue();
+    v = std::clamp(v, 1, 96);
+    editor.editorDawExtraState.mpeBendRange = v;
+    Synth::MainToAudioMsg m{Synth::MainToAudioMsg::SET_MPE_BEND_RANGE};
+    m.value = (float)v;
+    editor.mainToAudio.push(m);
+    refreshMpeRangeEditor();
+}
+
+// User-selectable smoothing values, in ms. Engine accepts any float; these are
+// just convenient presets surfaced in the menus.
+static constexpr std::array<float, 5> midiSmoothingChoicesMs{5.f, 10.f, 25.f, 50.f, 100.f};
+static constexpr std::array<float, 4> paramSmoothingChoicesMs{2.f, 5.f, 10.f, 25.f};
+
+static std::string formatSmoothingMs(float v)
+{
+    std::ostringstream oss;
+    if (v == (int)v)
+        oss << (int)v << "ms";
+    else
+        oss << v << "ms";
+    return oss.str();
+}
+
+void PlayModeSubPanel::refreshMidiSmoothingButton()
+{
+    auto text = formatSmoothingMs(editor.editorDawExtraState.midiCCSmoothingTimeMs);
+    midiSmoothingButton->setLabelAndTitle(text, "MIDI Smoothing " + text);
+    midiSmoothingButton->repaint();
+}
+
+void PlayModeSubPanel::showMidiSmoothingMenu()
+{
+    auto current = editor.editorDawExtraState.midiCCSmoothingTimeMs;
+    auto p = juce::PopupMenu();
+    p.addSectionHeader("MIDI Smoothing");
+    p.addSeparator();
+    for (auto ms : midiSmoothingChoicesMs)
+    {
+        bool ticked = std::abs(current - ms) < 0.001f;
+        p.addItem(formatSmoothingMs(ms), true, ticked,
+                  [w = juce::Component::SafePointer(this), ms]()
+                  {
+                      if (!w)
+                          return;
+                      w->editor.editorDawExtraState.midiCCSmoothingTimeMs = ms;
+                      Synth::MainToAudioMsg m{Synth::MainToAudioMsg::SET_MIDI_CC_SMOOTHING_TIME_MS};
+                      m.value = ms;
+                      w->editor.mainToAudio.push(m);
+                      w->refreshMidiSmoothingButton();
+                  });
+    }
+    p.showMenuAsync(juce::PopupMenu::Options().withParentComponent(&editor),
+                    makeMenuAccessibleButtonCB(midiSmoothingButton.get()));
+}
+
+void PlayModeSubPanel::refreshParamSmoothingButton()
+{
+    auto text = formatSmoothingMs(editor.editorDawExtraState.paramAutomationSmoothingTimeMs);
+    paramSmoothingButton->setLabelAndTitle(text, "Param Smoothing " + text);
+    paramSmoothingButton->repaint();
+}
+
+void PlayModeSubPanel::showParamSmoothingMenu()
+{
+    auto current = editor.editorDawExtraState.paramAutomationSmoothingTimeMs;
+    auto p = juce::PopupMenu();
+    p.addSectionHeader("Param Smoothing");
+    p.addSeparator();
+    for (auto ms : paramSmoothingChoicesMs)
+    {
+        bool ticked = std::abs(current - ms) < 0.001f;
+        p.addItem(formatSmoothingMs(ms), true, ticked,
+                  [w = juce::Component::SafePointer(this), ms]()
+                  {
+                      if (!w)
+                          return;
+                      w->editor.editorDawExtraState.paramAutomationSmoothingTimeMs = ms;
+                      Synth::MainToAudioMsg m{
+                          Synth::MainToAudioMsg::SET_PARAM_AUTOMATION_SMOOTHING_TIME_MS};
+                      m.value = ms;
+                      w->editor.mainToAudio.push(m);
+                      w->refreshParamSmoothingButton();
+                  });
+    }
+    p.showMenuAsync(juce::PopupMenu::Options().withParentComponent(&editor),
+                    makeMenuAccessibleButtonCB(paramSmoothingButton.get()));
 }
 
 } // namespace baconpaul::six_sines::ui

--- a/src/ui/playmode-sub-panel.h
+++ b/src/ui/playmode-sub-panel.h
@@ -18,6 +18,7 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <sst/jucegui/component-adapters/DiscreteToReference.h>
+#include <sst/jucegui/components/TextEditor.h>
 #include "six-sines-editor.h"
 #include "dahdsr-components.h"
 #include "lfo-components.h"
@@ -38,8 +39,7 @@ struct PlayModeSubPanel : juce::Component, HasEditor
     std::unique_ptr<jcmp::MultiSwitch> playMode;
     std::unique_ptr<PatchDiscrete> playModeD;
 
-    std::unique_ptr<jcmp::RuledLabel> bendTitle, uniTitle, mpeTitle, tsposeTitle, panicTitle,
-        mtsTitle;
+    std::unique_ptr<jcmp::RuledLabel> bendTitle, uniTitle, tsposeTitle, panicTitle, mtsTitle;
     std::unique_ptr<jcmp::Label> mtsStatusLabel;
     int mtsIdleCount{0};
     bool mtsConnected{false};
@@ -84,9 +84,19 @@ struct PlayModeSubPanel : juce::Component, HasEditor
         sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::ToggleButton, bool>>
         mpeActiveButtonD;
 
-    struct MpeBendRangeBinding;
-    std::unique_ptr<MpeBendRangeBinding> mpeRangeD;
+    std::unique_ptr<jcmp::TextEditor> mpeRangeEditor;
     std::unique_ptr<jcmp::Label> mpeRangeL;
+    void refreshMpeRangeEditor();
+    void commitMpeRangeEditor();
+
+    // "MPE + Smoothing" settings section below the top row.
+    std::unique_ptr<jcmp::RuledLabel> smoothingSectionTitle;
+    std::unique_ptr<jcmp::Label> mpeRowLabel, smoothingRowLabel, paramSmoothingRowLabel;
+    std::unique_ptr<jcmp::MenuButton> midiSmoothingButton, paramSmoothingButton;
+    void refreshMidiSmoothingButton();
+    void showMidiSmoothingMenu();
+    void refreshParamSmoothingButton();
+    void showParamSmoothingMenu();
 
     std::unique_ptr<jcmp::JogUpDownButton> tsposeButton;
     std::unique_ptr<PatchDiscrete> tsposeButtonD;


### PR DESCRIPTION
Adds two smoothing times (MIDI CC / MPE / note-expression at 25ms, param automation at 2ms) to the engine and DawExtraState, with menu pickers in the play-mode sub-panel and a typein for MPE bend range.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>