### PR TITLE
Fix the navigation menu for the 12 structure

### DIFF
--- a/doc/12_roadmap.md
+++ b/doc/12_roadmap.md
@@ -19,8 +19,8 @@ I have a lot of ideas for a '1.2' version of six sines. Not 2.0. Still compatibl
 - smoothing time as sliders
 - Smoothing and bend to engine side default (so move ui defaults to engine side)
 - why are voices and unison different widgets?
-- Oblisck: Unfortunately I ran into a crash. I clicked on "settings" in the macro window (the three dots)
-  And it instantly killed reaper.
+- Songpos phase for LFO
+- Engine- vs Voice- level for Macro LFOs
 
 ## Noise Upgrades **DONE**
 - Pink, White, Tilt (with N for tilt) **DONE**

--- a/src/ui/settings-panel.cpp
+++ b/src/ui/settings-panel.cpp
@@ -73,6 +73,11 @@ void SettingsPanel::beginEdit()
 
     editor.playModeSubPanel->setVisible(true);
     editor.singlePanel->setName("Settings");
+
+    // Light the button when entered via the nav menu (a direct click already
+    // sets the toggle before firing onValueChanged).
+    if (playScreenD)
+        playScreenD->setValueFromModel(true);
 }
 
 void SettingsPanel::clearHighlight()

--- a/src/ui/six-sines-editor.cpp
+++ b/src/ui/six-sines-editor.cpp
@@ -1213,6 +1213,7 @@ void SixSinesEditor::showNavigationMenu()
                    {
                        if (w)
                        {
+                           w->macroPanel->beginEdit(i);
                            w->macroPanel->knobs[i]->grabKeyboardFocus();
                        }
                    });
@@ -1238,9 +1239,20 @@ void SixSinesEditor::showNavigationMenu()
 
     p.addSeparator();
 
-    auto enam = std::string("Edit Area");
+    p.addItem("Settings",
+              [w = juce::Component::SafePointer(this)]()
+              {
+                  if (w)
+                  {
+                      w->settingsPanel->beginEdit();
+                      w->singlePanel->grabKeyboardFocus();
+                  }
+              });
+
+    p.addSeparator();
+    auto enam = std::string("Focus in Edit Area");
     if (!singlePanel->getName().isEmpty())
-        enam = "Edit " + singlePanel->getName().toStdString();
+        enam = "Focus " + singlePanel->getName().toStdString() + " Editor";
     p.addItem(enam,
               [w = juce::Component::SafePointer(this)]()
               {
@@ -1249,17 +1261,6 @@ void SixSinesEditor::showNavigationMenu()
                       w->singlePanel->grabKeyboardFocus();
                   }
               });
-
-    p.addItem("Settings",
-              [w = juce::Component::SafePointer(this)]()
-              {
-                  if (w)
-                  {
-                      w->mainPanel->beginEdit(3);
-                      w->singlePanel->grabKeyboardFocus();
-                  }
-              });
-
     p.addSeparator();
     p.addItem(spectrumWindow ? "Hide Analyzer" : "Show Analyzer",
               [w = juce::Component::SafePointer(this)]()


### PR DESCRIPTION
"Settings" didnt go to the right place leaving the UI in a state which could crash. Also re-organize a bit to make the focus jump clearer.

Assisted-By: Claude Opus 4.8