### PR TITLE
Keep noise tilt audible through the bit-rate crusher

### DIFF
--- a/doc/12_roadmap.md
+++ b/doc/12_roadmap.md
@@ -15,7 +15,6 @@ I have a lot of ideas for a '1.2' version of six sines. Not 2.0. Still compatibl
 
 ## Smaller Things from the crew
 - djTubig reports patch swapping kinda slow on windows. Look for profile?
-- Andreya reports tilt noise doesnt tilt with zoh time and stuff. why?
 - smoothing time as sliders
 - Smoothing and bend to engine side default (so move ui defaults to engine side)
 - why are voices and unison different widgets?

--- a/src/dsp/noise_helper.h
+++ b/src/dsp/noise_helper.h
@@ -24,6 +24,7 @@
 #include "sst/basic-blocks/dsp/RNG.h"
 #include "sst/basic-blocks/tables/DbToLinearProvider.h"
 #include "sst/filters/FastTiltNoiseFilter.h"
+#include "sst/filters/ButterworthLPHP.h"
 
 #include "synth/patch.h"
 
@@ -43,17 +44,24 @@ struct NoiseHelper
     // Tilt filter takes ±tiltMaxDb across the bipolar N range.
     static constexpr float tiltMaxDb{6.f};
 
-    struct Host
+    struct Config
     {
         const sst::basic_blocks::tables::DbToLinearProvider *db{nullptr};
+        double sr{48000.0};
         double sri{1.0 / 48000.0};
         float dbToLinear(float dbVal) { return db->dbToLinear(dbVal); }
         float getSampleRateInv() { return static_cast<float>(sri); }
-    } host;
+    } config;
 
     sst::basic_blocks::dsp::PinkNoise pinkNoise;
-    sst::filters::FastTiltNoiseFilter<Host> tiltFilter;
+    sst::filters::FastTiltNoiseFilter<Config> tiltFilter;
     sst::basic_blocks::dsp::RNG &rng;
+
+    // Anti-alias LP applied to the continuous noise colors (white/pink/tilt) ahead of
+    // the global bit-rate ZOH, so the ZOH has nothing above f_z/2 to fold (which would
+    // whiten the tilt). Cutoff tracks MonoValues::noiseBandLimitHz; 0 = no limit.
+    sst::filters::ButterworthLP<6> bandLimitFilter;
+    float lastBandLimitHz{-1.f};
 
     // 15-bit Galois LFSR shared by both chip modes. Seeded non-zero per helper
     // so simultaneous voices don't lock-step.
@@ -62,16 +70,38 @@ struct NoiseHelper
 
     NoiseHelper(sst::basic_blocks::dsp::RNG &r,
                 const sst::basic_blocks::tables::DbToLinearProvider &dbProv)
-        : pinkNoise(r.unifU32()), tiltFilter(host), rng(r)
+        : pinkNoise(r.unifU32()), tiltFilter(config), rng(r)
     {
-        host.db = &dbProv;
+        config.db = &dbProv;
         lfsrReg = static_cast<uint16_t>((r.unifU32() & 0x7FFFu) | 0x0001u);
     }
 
-    void setSampleRate(double sr) { host.sri = 1.0 / sr; }
+    void setSampleRate(double sr)
+    {
+        config.sr = sr;
+        config.sri = 1.0 / sr;
+    }
 
     // Map the patch's unipolar [0,1] N value onto a bipolar tilt gain in dB.
     static float nToTiltDb(float n) { return (n * 2.f - 1.f) * tiltMaxDb; }
+
+    // Anti-alias the 16-sample noise block to cutoffHz (== crusher Nyquist). 0 = no limit.
+    // Coeffs only recompute when the cutoff changes (rare); reset on change for stability.
+    void bandLimit16(float buf[16], float cutoffHz)
+    {
+        if (cutoffHz <= 0.f)
+            return;
+        // Empirically at 48khz ZOH the re-sample to audio output still reflects so scootch down a
+        // bit
+        cutoffHz = std::min(cutoffHz, 20000.f);
+        if (cutoffHz != lastBandLimitHz)
+        {
+            bandLimitFilter.setCutoffAndSampleRate(cutoffHz, static_cast<float>(config.sr));
+            bandLimitFilter.reset();
+            lastBandLimitHz = cutoffHz;
+        }
+        bandLimitFilter.processBlock(buf, 16);
+    }
 
     // Push 11 white samples through the tilt filter to prime its history.
     void warmup()
@@ -80,21 +110,26 @@ struct NoiseHelper
         for (int i = 0; i < 11; ++i)
             w[i] = rng.unifPM1();
         tiltFilter.init(w, nToTiltDb(0.5f));
+        bandLimitFilter.reset();
+        lastBandLimitHz = -1.f;
     }
 
     // Refill 16 samples of the chosen noise color into buf, normalized to ~±1.
     // baseFreq drives the LFSR shift clock when the mode is keytracked; otherwise
     // a fixed reference (lfsrFreeReferenceHz) is used.
-    void fill16(float buf[16], NoiseType type, float nValue, float baseFreq, LFSRMode lfsrMode)
+    void fill16(float buf[16], NoiseType type, float nValue, float baseFreq, LFSRMode lfsrMode,
+                float bandLimitHz)
     {
         switch (type)
         {
         case NoiseType::WHITE:
             for (int i = 0; i < 16; ++i)
                 buf[i] = rng.unifPM1();
+            bandLimit16(buf, bandLimitHz);
             break;
         case NoiseType::PINK:
             pinkNoise.generate16(buf);
+            bandLimit16(buf, bandLimitHz);
             break;
         case NoiseType::TILT:
         {
@@ -102,13 +137,14 @@ struct NoiseHelper
             // -4 dB/tiltDb attenuation to compensate for the high-shelf gain stack.
             auto tiltDb = std::clamp(nToTiltDb(nValue), -tiltMaxDb, tiltMaxDb);
             tiltFilter.setCoeff(tiltDb * 0.5f);
-            auto atten = (tiltDb > 0.f) ? host.dbToLinear(-4.f * tiltDb) : 1.f;
+            auto atten = (tiltDb > 0.f) ? config.dbToLinear(-4.f * tiltDb) : 1.f;
             for (int i = 0; i < 16; ++i)
             {
                 buf[i] = rng.unifPM1();
-                sst::filters::FastTiltNoiseFilter<Host>::step(tiltFilter, buf[i]);
+                sst::filters::FastTiltNoiseFilter<Config>::step(tiltFilter, buf[i]);
                 buf[i] *= atten;
             }
+            bandLimit16(buf, bandLimitHz);
             break;
         }
         case NoiseType::CHIP_LFSR:
@@ -120,7 +156,7 @@ struct NoiseHelper
             const int xorBit = isShort ? 6 : 1;
             const float refFreq = (keytrack ? baseFreq : 261.62) * lfsrFreeReferenceHz / 261.62;
             const float shiftFreq = refFreq * std::exp2((nValue - 0.5f) * lfsrTuningRange);
-            const double dPhase = static_cast<double>(shiftFreq) * host.sri;
+            const double dPhase = static_cast<double>(shiftFreq) * config.sri;
             for (int i = 0; i < 16; ++i)
             {
                 lfsrPhaseAcc += dPhase;

--- a/src/dsp/op_source.h
+++ b/src/dsp/op_source.h
@@ -673,7 +673,8 @@ struct alignas(16) OpSource : public EnvelopeSupport<Patch::SourceNode>,
             {
                 if (noisePos >= 16)
                 {
-                    noiseHelper.fill16(noiseBuf, noiseType, nextN, baseFrequency, lfsrMode);
+                    noiseHelper.fill16(noiseBuf, noiseType, nextN, baseFrequency, lfsrMode,
+                                       monoValues.noiseBandLimitHz);
                     noisePos = 0;
                 }
                 float noise = noiseBuf[noisePos++];

--- a/src/synth/mono_values.h
+++ b/src/synth/mono_values.h
@@ -89,6 +89,11 @@ struct MonoValues
 
     float audioInBlock alignas(16)[blockSize]{}; // engine-rate audio in, mono mix
 
+    // Anti-alias ceiling for the per-voice noise source = active bit-rate-crusher
+    // Nyquist (f_z/2), or 0 when the crusher is off (no limit). Derived in
+    // Synth::reapplyControlSettings so it can never drift from bitRateZOH's rate.
+    float noiseBandLimitHz{0.f};
+
     // Instance-scoped MPE config — lives on the engine, NOT in the patch. Persisted
     // via Synth::DawExtraState so DAW sessions round-trip without polluting patches.
     bool mpeActive{false};

--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -1049,6 +1049,13 @@ void Synth::reapplyControlSettings()
         }
         bitRateZOH.setRate(target, sr);
         bitRateZOH.reset();
+        // Band-limit the per-voice noise to the crusher Nyquist so the ZOH has
+        // nothing above its Nyquist to fold (which would whiten the tilt).
+        monoValues.noiseBandLimitHz = target * 0.5f;
+    }
+    else
+    {
+        monoValues.noiseBandLimitHz = 0.f;
     }
 
     auto hpVal = (int)std::round(patch.output.highpass.value);

--- a/src/ui/source-sub-panel.cpp
+++ b/src/ui/source-sub-panel.cpp
@@ -509,7 +509,7 @@ struct NoisePainter : juce::Component
 
             if (noisePos >= 16)
             {
-                helper.fill16(noiseBuf, nt, nVal, 220.f, lm);
+                helper.fill16(noiseBuf, nt, nVal, 220.f, lm, 0.f);
                 noisePos = 0;
             }
             float n = noiseBuf[noisePos++];


### PR DESCRIPTION
Colored noise (white/pink/tilt) was generated full-bandwidth at the engine rate, so the global bit-rate ZOH folded its whole spectrum down into the crush band and averaged the tilt slope away to white.

Band-limit the noise source to the crusher's Nyquist before it enters the matrix, so the downstream ZOH has nothing above its Nyquist to fold. The ceiling is derived alongside the crusher rate in reapplyControlSettings so the two can never drift, and applies only to the continuous colors; the chip LFSR is left raw.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>