### PR TITLE
Add a song-position run mode for LFOs

### DIFF
--- a/doc/12_roadmap.md
+++ b/doc/12_roadmap.md
@@ -16,8 +16,6 @@ I have a lot of ideas for a '1.2' version of six sines. Not 2.0. Still compatibl
 ## Smaller Things from the crew
 - djTubig reports patch swapping kinda slow on windows. Look for profile?
 - Smoothing and bend to engine side default (so move ui defaults to engine side)
-- Songpos phase for LFO
-- Engine- vs Voice- level for Macro LFOs
 
 ## Noise Upgrades **DONE**
 - Pink, White, Tilt (with N for tilt) **DONE**

--- a/src/clap/six-sines-clap.cpp
+++ b/src/clap/six-sines-clap.cpp
@@ -165,11 +165,24 @@ struct SixSinesClap : public plugHelper_t, sst::clap_juce_shim::EditorProvider
         if (process->transport)
         {
             engine->monoValues.tempoSyncRatio = process->transport->tempo / 120.0;
+            auto tflags = process->transport->flags;
+            // Only trust the song position when the host is both playing and exposes a
+            // seconds timeline; otherwise free-run our own clock.
+            engine->monoValues.isPlayingAndHasSecondsTimeline =
+                (tflags & CLAP_TRANSPORT_IS_PLAYING) &&
+                (tflags & CLAP_TRANSPORT_HAS_SECONDS_TIMELINE);
+            if (engine->monoValues.isPlayingAndHasSecondsTimeline)
+                engine->monoValues.hostSongPosSeconds =
+                    process->transport->song_pos_seconds / (double)CLAP_SECTIME_FACTOR;
         }
         else
         {
             engine->monoValues.tempoSyncRatio = 1.f;
+            engine->monoValues.isPlayingAndHasSecondsTimeline = false;
         }
+        // Re-anchor songPosSeconds to the host position on the first engine block of this
+        // buffer; subsequent blocks advance from there.
+        engine->monoValues.songPosNeedsResync = true;
 
         static constexpr int outBus{multiOut ? 1 + numOps : 1};
         static constexpr int outChan{multiOut ? (1 + numOps) * 2 : 2};

--- a/src/dsp/node_support.h
+++ b/src/dsp/node_support.h
@@ -282,7 +282,7 @@ template <typename Parent, typename T, bool needsSmoothing = true> struct LFOSup
     MonoValues &monoValues; // non-const so we can read the RNG
 
     const float &lfoRate, &lfoDeform, &lfoShape, &lfoActiveV, &tempoSyncV, &bipolarV,
-        &lfoIsEnvelopedV, &lfoStartPhase;
+        &lfoIsEnvelopedV, &lfoStartPhase, &runModeV;
     bool active, doSmooth{false};
     using lfo_t = sst::basic_blocks::modulators::SimpleLFO<SRProvider, blockSize>;
     lfo_t lfo;
@@ -300,7 +300,7 @@ template <typename Parent, typename T, bool needsSmoothing = true> struct LFOSup
         : paramBundle(mn), lfo(&mv.sr, mv.rng), stepLFO(mv.tuningProvider), lfoRate(mn.lfoRate),
           lfoDeform(mn.lfoDeform), lfoShape(mn.lfoShape), lfoActiveV(mn.lfoActive),
           tempoSyncV(mn.tempoSync), monoValues(mv), bipolarV(mn.lfoBipolar),
-          lfoIsEnvelopedV(mn.lfoIsEnveloped), lfoStartPhase(mn.lfoStartPhase),
+          lfoIsEnvelopedV(mn.lfoIsEnveloped), lfoStartPhase(mn.lfoStartPhase), runModeV(mn.runMode),
           stepValues(sst::cpputils::make_array_lambda<const float *, numSeqSteps>(
               [&mn](int i) { return &mn.lfoSeqSteps[i].value; })),
           stepCountValue(&mn.lfoStepCount.value), stepCycleModeValue(&mn.lfoCycleMode.value)
@@ -326,6 +326,19 @@ template <typename Parent, typename T, bool needsSmoothing = true> struct LFOSup
     bool tempoSync{false};
     bool bipolar{true};
     bool lfoIsEnveloped{false};
+    int runMode{Patch::LFOMixin::VOICE_TRIGGER};
+
+    // Map the engine song position onto an LFO phase in [0,1) for SONGPOS run mode.
+    // rate is the log2 LFO frequency; the instantaneous frequency is tsScale * 2^rate Hz
+    // (tsScale = tempoSyncRatio under temposync, matching SimpleLFO::process_block), so the
+    // phase at songPosSeconds is (songPosSeconds * tsScale * 2^rate) wrapped to one cycle.
+    float songPosToPhase(float rate, double tsScale = 1.0) const
+    {
+        auto freqHz = monoValues.twoToTheX.twoToThe(rate) * tsScale;
+        auto phase = monoValues.songPosSeconds * freqHz;
+        phase -= std::floor(phase);
+        return (float)phase;
+    }
 
     bool runLfo{false};
     int32_t runLfoCheck{0};
@@ -339,6 +352,7 @@ template <typename Parent, typename T, bool needsSmoothing = true> struct LFOSup
         bipolar = bipolarV > 0.5;
         lfoIsEnveloped = lfoIsEnvelopedV > 0.5;
         shape = static_cast<int>(std::round(lfoShape));
+        runMode = static_cast<int>(std::round(runModeV));
 
         // Shape is latched at attack time; lfoProcess assumes the matching
         // oscillator was initialized here. If shape is ever allowed to change
@@ -348,19 +362,56 @@ template <typename Parent, typename T, bool needsSmoothing = true> struct LFOSup
             snapStepStorageFromParams();
             stepLFO.setSampleRate(monoValues.sr.sampleRate, monoValues.sr.sampleRateInv);
             stepTransport.tempo = monoValues.tempoSyncRatio * 120.0;
-            auto useRate = std::clamp(lfoRate + lfoRateMod, paramBundle.lfoRate.meta.minVal,
+            // Snap to temposync as lfoProcess does, so the song-position lock and the
+            // free-run increment use the same rate.
+            auto snapRate = lfoRate;
+            if (tempoSync)
+                snapRate = -paramBundle.lfoRate.meta.snapToTemposync(-snapRate);
+            auto useRate = std::clamp(snapRate + lfoRateMod, paramBundle.lfoRate.meta.minVal,
                                       paramBundle.lfoRate.meta.maxVal);
             stepLFO.assign(&stepStorage, useRate, &stepTransport, monoValues.rng, tempoSync);
 
-            double phase0 =
+            // Start position expressed as a continuous step index (integer part = step,
+            // fractional part = phase within the step). The user start phase is a fraction
+            // of the whole sequence.
+            double total =
                 std::clamp(lfoStartPhase + lfoStartMod, 0.f, 0.999f) * stepStorage.repeat;
-            double phaseFr = phase0 - std::floor(phase0);
-            stepLFO.setPhaseTo((int)std::floor(phase0), (float)phaseFr);
+            if (runMode == Patch::LFOMixin::SONGPOS)
+            {
+                // Steps advance at 2^rate per second, scaled by the whole-sequence length
+                // in cycle mode (rateIsForSingleStep == false) and by tempo when synced,
+                // matching StepLFO::UpdatePhaseIncrement.
+                double stepsPerSec =
+                    monoValues.twoToTheX.twoToThe(useRate) *
+                    (stepStorage.rateIsForSingleStep ? 1.0 : (double)stepStorage.repeat);
+                if (tempoSync)
+                    stepsPerSec *= monoValues.tempoSyncRatio;
+                total += monoValues.songPosSeconds * stepsPerSec;
+            }
+            long totalFloor = (long)std::floor(total);
+            double phaseFr = total - (double)totalFloor;
+            int step = (int)(((totalFloor % stepStorage.repeat) + stepStorage.repeat) %
+                             stepStorage.repeat);
+            stepLFO.setPhaseTo(step, (float)phaseFr);
         }
         else
         {
             lfo.attack(shape);
-            lfo.applyPhaseOffset(lfoStartPhase + lfoStartMod);
+            float phaseOffset = lfoStartPhase + lfoStartMod;
+            if (runMode == Patch::LFOMixin::SONGPOS)
+            {
+                // Derive the start phase from the song position rather than the note
+                // attack. Mirror the effective rate lfoProcess uses so the locked phase
+                // matches the free-run frequency.
+                auto effRate = lfoRate;
+                if (tempoSync)
+                    effRate = -paramBundle.lfoRate.meta.snapToTemposync(-effRate);
+                effRate = std::clamp(effRate + lfoRateMod, paramBundle.lfoRate.meta.minVal,
+                                     paramBundle.lfoRate.meta.maxVal);
+                phaseOffset += songPosToPhase(effRate, tempoSync ? monoValues.tempoSyncRatio : 1.0);
+                phaseOffset -= std::floor(phaseOffset);
+            }
+            lfo.applyPhaseOffset(phaseOffset);
         }
         if (needsSmoothing)
         {

--- a/src/synth/mono_values.h
+++ b/src/synth/mono_values.h
@@ -59,6 +59,19 @@ struct MonoValues
     }
 
     float tempoSyncRatio{1};
+
+    // Transport state, refreshed each host buffer from the CLAP transport. songPosSeconds
+    // re-anchors to hostSongPosSeconds at the top of each buffer (songPosNeedsResync) and
+    // then advances by blockSize/hostSampleRate per engine block, so it stays sample-locked
+    // to the host across wide buffers. When the host is stopped, gives no seconds timeline,
+    // or supplies no transport at all, isPlayingAndHasSecondsTimeline is false and the clock
+    // simply free-runs by the same per-block advance, a monotonic clock for the life of the
+    // engine.
+    bool isPlayingAndHasSecondsTimeline{false};
+    bool songPosNeedsResync{false};
+    double hostSongPosSeconds{0.0};
+    double songPosSeconds{0.0};
+
     float pitchBend{0.f};
     std::array<int8_t, 128> midiCC;
     std::array<float, 128> midiCCFloat; // 0...1 normed

--- a/src/synth/patch.h
+++ b/src/synth/patch.h
@@ -93,6 +93,8 @@ struct Patch : pats::PatchBase<Patch, Param>
     static constexpr uint64_t version_120e = 0x010205;
     // Sixth chunk of 1.2.0: pink-noise extended mode
     static constexpr uint64_t version_120f = 0x010206;
+    // Seventh chunk of 1.2.0: LFO song-position run mode
+    static constexpr uint64_t version_120g = 0x010207;
 
     static md_t baseMd(uint64_t version = version_110) { return md_t().withVersion(version); }
     static md_t floatMd(uint64_t version = version_110)
@@ -192,6 +194,12 @@ struct Patch : pats::PatchBase<Patch, Param>
             Step
         };
 
+        enum LfoRunMode
+        {
+            VOICE_TRIGGER = 0,
+            SONGPOS
+        };
+
         LFOMixin(const std::string name, int id0, int stepid0 = -1, uint64_t version = version_110)
             : lfoRate(floatMd(version)
                           .asLfoRate(-7, 11)
@@ -269,13 +277,21 @@ struct Patch : pats::PatchBase<Patch, Param>
                                .withName(name + " Cycle")
                                .withDefault(0)
                                .withGroupName(name)
-                               .withID(((stepid0 > 0 ? (stepid0) : (id0 + 9)) + 17)))
+                               .withID(((stepid0 > 0 ? (stepid0) : (id0 + 9)) + 17))),
+              runMode(intMd(version_120g)
+                          .withName(name + " LFO Run Mode")
+                          .withGroupName(name)
+                          .withRange(LfoRunMode::VOICE_TRIGGER, LfoRunMode::SONGPOS)
+                          .withDefault(LfoRunMode::VOICE_TRIGGER)
+                          .withID(stepid0 > 0 ? (id0 + 9) : (id0 + 27))
+                          .withUnorderedMapFormatting({{LfoRunMode::VOICE_TRIGGER, "retrig"},
+                                                       {LfoRunMode::SONGPOS, "song"}}))
         {
             lfoRate.tempoSyncPartner = &tempoSync;
         }
 
         Param lfoRate, lfoDeform, lfoShape, lfoActive, tempoSync, lfoBipolar, lfoIsEnveloped,
-            lfoStartPhase, lfoStepCount, lfoCycleMode;
+            lfoStartPhase, lfoStepCount, lfoCycleMode, runMode;
         std::array<Param, numSeqSteps> lfoSeqSteps;
 
         void appendLFOParams(std::vector<Param *> &res)
@@ -293,6 +309,7 @@ struct Patch : pats::PatchBase<Patch, Param>
             }
             res.push_back(&lfoStepCount);
             res.push_back(&lfoCycleMode);
+            res.push_back(&runMode);
         }
 
         enum LFOTargets

--- a/src/synth/synth.cpp
+++ b/src/synth/synth.cpp
@@ -310,6 +310,16 @@ template <bool multiOut> void Synth::processInternal(const clap_output_events_t 
 
     monoValues.attackFloorOnRetrig = patch.output.attackFloorOnRetrig > 0.5;
 
+    // Advance the song-position clock once per host block. On the first block of a host
+    // buffer, re-anchor to the host position (when playing with a seconds timeline); every
+    // other block — and the whole free-run case — advances by the real elapsed block time.
+    // This keeps us sample-locked to the host even across wide (e.g. 4096) buffers.
+    if (monoValues.isPlayingAndHasSecondsTimeline && monoValues.songPosNeedsResync)
+        monoValues.songPosSeconds = monoValues.hostSongPosSeconds;
+    else
+        monoValues.songPosSeconds += (double)blockSize / hostSampleRate;
+    monoValues.songPosNeedsResync = false;
+
     int loops{0};
 
     SRC_DATA d;

--- a/src/ui/lfo-components.h
+++ b/src/ui/lfo-components.h
@@ -21,6 +21,7 @@
 #include <sst/jucegui/components/HSliderFilled.h>
 #include <sst/jucegui/components/Label.h>
 #include <sst/jucegui/components/MultiSwitch.h>
+#include <sst/jucegui/components/MenuButton.h>
 #include <sst/jucegui/components/JogUpDownButton.h>
 #include "patch-data-bindings.h"
 #include "ui-constants.h"
@@ -251,13 +252,32 @@ template <typename Comp, typename Patch> struct LFOComponents
 
         createComponent(e, *c, v.lfoBipolar, bipolar, bipolarD);
         bipolar->setDrawMode(jcmp::ToggleButton::DrawMode::LABELED);
-        bipolar->setLabel("Bipolar");
+        bipolar->setLabel("bip");
         c->addAndMakeVisible(*bipolar);
 
         createComponent(e, *c, v.lfoIsEnveloped, isEnv, isEnvD);
         isEnv->setDrawMode(jcmp::ToggleButton::DrawMode::LABELED);
-        isEnv->setLabel("* Env");
+        isEnv->setLabel("*env");
         c->addAndMakeVisible(*isEnv);
+
+        // Short text ("retrig"/"song") on the button face, long names in the popup, so
+        // the button stays compact while the menu reads clearly.
+        runModeD = std::make_unique<PatchDiscrete>(e, v.runMode.meta.id);
+        runModeId = v.runMode.meta.id;
+        runMode = std::make_unique<jcmp::MenuButton>();
+        resetRunModeLabel();
+        runMode->setOnCallback(
+            [w = juce::Component::SafePointer(c)]()
+            {
+                if (w)
+                    w->showRunModeMenu();
+            });
+        c->addAndMakeVisible(*runMode);
+        e.componentRefreshByID[v.runMode.meta.id] = [w = juce::Component::SafePointer(c)]()
+        {
+            if (w)
+                w->resetRunModeLabel();
+        };
 
         stepEditor = std::make_unique<StepEditor>(e, v);
         c->addAndMakeVisible(*stepEditor);
@@ -291,6 +311,7 @@ template <typename Comp, typename Patch> struct LFOComponents
         sst::jucegui::component_adapters::setTraversalId(rate.get(), 203);
         sst::jucegui::component_adapters::setTraversalId(deform.get(), 205);
         sst::jucegui::component_adapters::setTraversalId(isEnv.get(), 211);
+        sst::jucegui::component_adapters::setTraversalId(runMode.get(), 212);
 
         lfoSetEnabledState(true);
     }
@@ -308,10 +329,47 @@ template <typename Comp, typename Patch> struct LFOComponents
         tempoSync->setEnabled(globallyEnabled);
         bipolar->setEnabled(globallyEnabled && !isStep);
         isEnv->setEnabled(globallyEnabled);
+        runMode->setEnabled(globallyEnabled);
         stepCount->setEnabled(globallyEnabled && isStep);
         cycleMode->setEnabled(globallyEnabled && isStep);
         stepEditor->setEnabled(globallyEnabled && isStep);
         asComp()->repaint();
+    }
+
+    void resetRunModeLabel()
+    {
+        if (runMode && runModeD)
+            runMode->setLabel(runModeD->getValueAsString());
+    }
+
+    void showRunModeMenu()
+    {
+        auto &editor = asComp()->editor;
+        auto cur = (int)std::round(runModeD->getValue());
+
+        auto p = juce::PopupMenu();
+        p.addSectionHeader("LFO Run Mode");
+        p.addSeparator();
+        p.addItem("Retrigger on Attack", true, cur == Patch::VOICE_TRIGGER,
+                  [w = juce::Component::SafePointer(asComp())]()
+                  {
+                      if (w)
+                          w->setRunMode(Patch::VOICE_TRIGGER);
+                  });
+        p.addItem("Song Position", true, cur == Patch::SONGPOS,
+                  [w = juce::Component::SafePointer(asComp())]()
+                  {
+                      if (w)
+                          w->setRunMode(Patch::SONGPOS);
+                  });
+        p.showMenuAsync(juce::PopupMenu::Options().withParentComponent(&editor),
+                        makeMenuAccessibleButtonCB(runMode.get()));
+    }
+
+    void setRunMode(int v)
+    {
+        asComp()->editor.setAndSendParamValue(runModeId, v);
+        resetRunModeLabel();
     }
 
     juce::Rectangle<int> layoutLFOAt(int x, int y, int width = -1)
@@ -333,14 +391,17 @@ template <typename Comp, typename Patch> struct LFOComponents
         auto col1 = jlo::VList().withWidth(uicKnobSize * 1.5).withAutoGap(uicMargin);
         col1.add(jlo::Component(*shape).withHeight(uicLabeledKnobHeight + 3 * uicMargin +
                                                    3 * uicLabelHeight));
-        col1.add(jlo::Component(*bipolar).withHeight(uicLabelHeight));
+        auto toggleRow = jlo::HList().withHeight(uicLabelHeight).withAutoGap(uicMargin);
+        toggleRow.add(jlo::Component(*bipolar).expandToFill());
+        toggleRow.add(jlo::Component(*isEnv).expandToFill());
+        col1.add(toggleRow);
 
         auto col2 = jlo::VList().withWidth(uicKnobSize * 1.25).withAutoGap(uicMargin);
         col2.add(labelKnobLayout(rate, rateL).centerInParent());
         col2.add(jlo::Component(*tempoSync).withHeight(uicLabelHeight));
         col2.add(sideLabelSlider(deformL, deform));
         col2.add(sideLabelSlider(phaseL, phase));
-        col2.add(jlo::Component(*isEnv).withHeight(uicLabelHeight));
+        col2.add(jlo::Component(*runMode).withHeight(uicLabelHeight));
 
         auto col3 = jlo::VList().expandToFill().withAutoGap(0);
         col3.add(jlo::Component(*stepEditor).expandToFill());
@@ -378,6 +439,10 @@ template <typename Comp, typename Patch> struct LFOComponents
 
     std::unique_ptr<jcmp::ToggleButton> isEnv;
     std::unique_ptr<PatchDiscrete> isEnvD;
+
+    std::unique_ptr<jcmp::MenuButton> runMode;
+    std::unique_ptr<PatchDiscrete> runModeD;
+    uint32_t runModeId{0};
 
     std::unique_ptr<StepEditor> stepEditor;
 


### PR DESCRIPTION
LFOs can now lock their phase to the host timeline instead of the note attack. Each LFO gains a run mode that selects between "retrigger on attack" (the previous behaviour) and "song position", which derives the initial phase from where the transport sits in the song. This works for both the continuous and step LFOs and stays locked with or without temposync.

To support it the engine tracks the song position in seconds off the CLAP transport, re-anchoring to the host at the top of each buffer and advancing per block so it stays sample-locked across wide buffers. When the host is stopped or exposes no seconds timeline, the clock free-runs on its own.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>