### PR TITLE
Add MPE Timbre (Bipolar) as a modulator

### DIFF
--- a/src/dsp/node_support.h
+++ b/src/dsp/node_support.h
@@ -662,6 +662,9 @@ template <typename Bundle, typename Node> struct ModulationSupport
         case ModMatrixConfig::Source::MPE_TIMBRE:
             sourcePointers[which] = &voiceValues.mpeTimbreLag.v;
             break;
+        case ModMatrixConfig::Source::MPE_TIMBRE_BIPOLAR:
+            sourcePointers[which] = &voiceValues.mpeTimbreBipolarLag.v;
+            break;
         case ModMatrixConfig::Source::MPE_PITCHBEND:
             sourcePointers[which] = &voiceValues.mpeBendInSemisLag.v;
             break;

--- a/src/synth/mod_matrix.cpp
+++ b/src/synth/mod_matrix.cpp
@@ -59,6 +59,7 @@ ModMatrixConfig::ModMatrixConfig()
 
     add(MPE_PRESSURE, "MPE", "Pressure");
     add(MPE_TIMBRE, "MPE", "Timbre");
+    add(MPE_TIMBRE_BIPOLAR, "MPE", "Timbre (Bipolar)");
 
     add(RANDOM_01, "Random", "Rand Unif 01");
     add(RANDOM_PM1, "Random", "Rand Unif Bi");

--- a/src/synth/mod_matrix.h
+++ b/src/synth/mod_matrix.h
@@ -55,6 +55,7 @@ struct ModMatrixConfig
         MPE_PRESSURE = voiceLevel + 100,
         MPE_TIMBRE = voiceLevel + 101,
         MPE_PITCHBEND = voiceLevel + 102,
+        MPE_TIMBRE_BIPOLAR = voiceLevel + 103,
 
         RANDOM_01 = voiceLevel + 200,
         RANDOM_PM1 = voiceLevel + 201,

--- a/src/synth/synth.h
+++ b/src/synth/synth.h
@@ -254,7 +254,13 @@ struct Synth
         {
             v->voiceValues.mpePressure = p / 127.0;
         }
-        void setVoiceMIDIMPETimbre(Voice *v, int8_t t) { v->voiceValues.mpeTimbre = t / 127.0; }
+        void setVoiceMIDIMPETimbre(Voice *v, int8_t t)
+        {
+            v->voiceValues.mpeTimbre = t / 127.0;
+            // Bipolar: 64 -> 0, 0 -> -1, 127 -> +1. The lower half has one extra
+            // tick (0..63 vs 65..127), so the bottom tick clamps to -1.
+            v->voiceValues.mpeTimbreBipolar = std::clamp((t - 64) / 63.0, -1.0, 1.0);
+        }
     };
     struct VMMonoResponder
     {

--- a/src/synth/voice.cpp
+++ b/src/synth/voice.cpp
@@ -65,6 +65,8 @@ void Voice::attack()
                                                         1.0 / blockSize);
     voiceValues.mpeTimbreLag.setRateInMilliseconds(mpeLagMs, monoValues.sr.sampleRate,
                                                    1.0 / blockSize);
+    voiceValues.mpeTimbreBipolarLag.setRateInMilliseconds(mpeLagMs, monoValues.sr.sampleRate,
+                                                          1.0 / blockSize);
     voiceValues.mpePressureLag.setRateInMilliseconds(mpeLagMs, monoValues.sr.sampleRate,
                                                      1.0 / blockSize);
     voiceValues.noteExpressionTuningInSemisLag.setRateInMilliseconds(
@@ -106,6 +108,7 @@ void Voice::renderBlock()
     };
     stepLag(voiceValues.mpeBendInSemisLag, voiceValues.mpeBendInSemis);
     stepLag(voiceValues.mpeTimbreLag, voiceValues.mpeTimbre);
+    stepLag(voiceValues.mpeTimbreBipolarLag, voiceValues.mpeTimbreBipolar);
     stepLag(voiceValues.mpePressureLag, voiceValues.mpePressure);
     stepLag(voiceValues.noteExpressionTuningInSemisLag, voiceValues.noteExpressionTuningInSemis);
     stepLag(voiceValues.noteExpressionPanBipolarLag, voiceValues.noteExpressionPanBipolar);
@@ -355,6 +358,7 @@ void Voice::cleanup()
     voiceValues.mpeBendInSemis = 0;
     voiceValues.mpeBendNormalized = 0;
     voiceValues.mpeTimbre = 0;
+    voiceValues.mpeTimbreBipolar = 0;
     voiceValues.mpePressure = 0;
     voiceValues.noteExpressionTuningInSemis = 0;
     voiceValues.noteExpressionPanBipolar = 0;

--- a/src/synth/voice_values.h
+++ b/src/synth/voice_values.h
@@ -53,7 +53,8 @@ struct VoiceValues
     float portaDiff{0}, dPorta{0}, portaFrac{0}, dPortaFrac{0};
     int portaSign{0};
 
-    float mpeBendInSemis{0}, mpeBendNormalized{0}, mpeTimbre{0}, mpePressure{0};
+    float mpeBendInSemis{0}, mpeBendNormalized{0}, mpeTimbre{0}, mpeTimbreBipolar{0},
+        mpePressure{0};
 
     float noteExpressionTuningInSemis{0}, noteExpressionPanBipolar{0};
 
@@ -71,6 +72,7 @@ struct VoiceValues
     // for MPE_* point at the corresponding lag's .v (see node_support.h).
     sst::basic_blocks::dsp::OnePoleLag<float, false> mpeBendInSemisLag;
     sst::basic_blocks::dsp::OnePoleLag<float, false> mpeTimbreLag;
+    sst::basic_blocks::dsp::OnePoleLag<float, false> mpeTimbreBipolarLag;
     sst::basic_blocks::dsp::OnePoleLag<float, false> mpePressureLag;
     sst::basic_blocks::dsp::OnePoleLag<float, false> noteExpressionTuningInSemisLag;
     sst::basic_blocks::dsp::OnePoleLag<float, false> noteExpressionPanBipolarLag;


### PR DESCRIPTION
Add a bipolar (1...127 -> -1...1 with 64 -> 0) MPE Timbre modulator to the modulation source set.

Assisted-By: Claude Opus 4.8